### PR TITLE
feat: Driver Incident Submission Interface (#280)

### DIFF
--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -131,3 +131,70 @@ class DashboardResponse(BaseModel):
 
     role: str
     stats: list[StatItem]
+
+
+class CreateIncidentRequest(BaseModel):
+    """Request schema for creating an incident."""
+
+    type: Literal["breakdown", "accident", "delay"] = Field(
+        ..., description="Type of incident"
+    )
+    severity: Literal["low", "medium", "high", "critical"] = Field(
+        ..., description="Severity level of the incident"
+    )
+    description: str = Field(
+        ...,
+        min_length=1,
+        max_length=1000,
+        description="Description of the incident",
+    )
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "type": "breakdown",
+                    "severity": "high",
+                    "description": (
+                        "Vehicle engine overheating on Route 5"
+                    ),
+                }
+            ]
+        }
+    }
+
+
+class IncidentResponse(BaseModel):
+    """Response schema for a single incident."""
+
+    id: str
+    driver_id: str
+    type: str
+    severity: str
+    description: str
+    status: str
+    created_at: str | None = None
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "id": "1",
+                    "driver_id": "6",
+                    "type": "breakdown",
+                    "severity": "high",
+                    "description": (
+                        "Vehicle engine overheating on Route 5"
+                    ),
+                    "status": "open",
+                    "created_at": "2026-03-26T10:30:00",
+                }
+            ]
+        }
+    }
+
+
+class IncidentListResponse(BaseModel):
+    """Response schema for list of incidents."""
+
+    incidents: list[IncidentResponse]

--- a/backend/app/api/v1/endpoints/__init__.py
+++ b/backend/app/api/v1/endpoints/__init__.py
@@ -1,5 +1,6 @@
 """API v1 endpoints."""
 
-from app.api.v1.endpoints import auth, health
+from app.api.v1.endpoints import auth, health, incidents
 
-__all__ = ["auth", "health"]
+__all__ = ["auth", "health", "incidents"]
+

--- a/backend/app/api/v1/endpoints/__init__.py
+++ b/backend/app/api/v1/endpoints/__init__.py
@@ -3,4 +3,3 @@
 from app.api.v1.endpoints import auth, health, incidents
 
 __all__ = ["auth", "health", "incidents"]
-

--- a/backend/app/api/v1/endpoints/dashboard.py
+++ b/backend/app/api/v1/endpoints/dashboard.py
@@ -60,5 +60,12 @@ async def get_dashboard_stats(
             StatItem(label="Overall GPA", value="3.8"),
             StatItem(label="Assignments Due", value=3),
         ]
+    elif role == "driver":
+        role_label = "Driver"
+        stats = [
+            StatItem(label="Total Incidents", value=0),
+            StatItem(label="Active Route", value="Route 5"),
+            StatItem(label="Vehicle Status", value="Active"),
+        ]
 
     return DashboardResponse(role=role_label, stats=stats)

--- a/backend/app/api/v1/endpoints/incidents.py
+++ b/backend/app/api/v1/endpoints/incidents.py
@@ -1,0 +1,88 @@
+"""
+Incident API endpoints.
+
+Provides endpoints for creating and listing driver incidents.
+Follows the same pattern as dashboard.py.
+"""
+
+from fastapi import APIRouter, Depends, status
+
+from app.api.dependencies import get_current_user
+from app.api.schemas import (
+    CreateIncidentRequest,
+    IncidentListResponse,
+    IncidentResponse,
+)
+from app.domain.entities.user import User
+from app.domain.usecases.incident_usecases import (
+    CreateIncidentUseCase,
+    GetDriverIncidentsUseCase,
+)
+from app.infrastructure.repositories.database_incident_repository import (
+    DatabaseIncidentRepository,
+)
+
+router = APIRouter(prefix="/incidents", tags=["Incidents"])
+
+# Dependency injection
+incident_repository = DatabaseIncidentRepository()
+create_incident_usecase = CreateIncidentUseCase(incident_repository)
+get_driver_incidents_usecase = GetDriverIncidentsUseCase(incident_repository)
+
+
+@router.post(
+    "",
+    response_model=IncidentResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Report a new incident",
+    description=(
+        "Create a new incident report. "
+        "Only accessible to authenticated drivers."
+    ),
+)
+async def create_incident(
+    request: CreateIncidentRequest,
+    current_user: User = Depends(get_current_user),
+) -> IncidentResponse:
+    """
+    Create a new incident endpoint.
+
+    Allows drivers to report breakdowns, accidents, or delays.
+    """
+    incident = await create_incident_usecase.execute(
+        driver_id=current_user.id,
+        incident_type=request.type,
+        severity=request.severity,
+        description=request.description,
+    )
+
+    return IncidentResponse(**incident.to_dict())
+
+
+@router.get(
+    "",
+    response_model=IncidentListResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Get driver's incidents",
+    description=(
+        "Retrieve all incidents reported by the authenticated driver."
+    ),
+)
+async def get_incidents(
+    current_user: User = Depends(get_current_user),
+) -> IncidentListResponse:
+    """
+    Get incidents endpoint.
+
+    Returns all incidents reported by the current driver,
+    ordered by most recent first.
+    """
+    incidents = await get_driver_incidents_usecase.execute(
+        driver_id=current_user.id
+    )
+
+    return IncidentListResponse(
+        incidents=[
+            IncidentResponse(**i.to_dict()) for i in incidents
+        ]
+    )

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -6,7 +6,7 @@ This module aggregates all v1 API endpoints.
 
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import auth, health, dashboard
+from app.api.v1.endpoints import auth, dashboard, health, incidents
 
 # Create v1 router
 router = APIRouter(prefix="/v1")
@@ -15,3 +15,4 @@ router = APIRouter(prefix="/v1")
 router.include_router(auth.router)
 router.include_router(health.router)
 router.include_router(dashboard.router)
+router.include_router(incidents.router)

--- a/backend/app/domain/entities/incident.py
+++ b/backend/app/domain/entities/incident.py
@@ -1,0 +1,54 @@
+"""
+Domain entity for Incidents.
+
+Represents an incident reported by a driver,
+such as a vehicle breakdown, accident, or delay.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal
+
+
+# Type aliases for incident fields
+IncidentType = Literal["breakdown", "accident", "delay"]
+IncidentSeverity = Literal["low", "medium", "high", "critical"]
+IncidentStatus = Literal["open", "acknowledged", "resolved"]
+
+
+@dataclass
+class Incident:
+    """
+    Incident entity.
+
+    Attributes:
+        id: Unique identifier for the incident
+        driver_id: ID of the driver who reported the incident
+        type: Type of incident (breakdown, accident, delay)
+        severity: Severity level (low, medium, high, critical)
+        description: Free-text description of the incident
+        status: Current status (open, acknowledged, resolved)
+        created_at: When the incident was reported
+    """
+
+    id: str
+    driver_id: str
+    type: IncidentType
+    severity: IncidentSeverity
+    description: str
+    status: IncidentStatus = "open"
+    created_at: datetime | None = None
+
+    def to_dict(self) -> dict:
+        """Convert entity to dictionary representation."""
+        return {
+            "id": self.id,
+            "driver_id": self.driver_id,
+            "type": self.type,
+            "severity": self.severity,
+            "description": self.description,
+            "status": self.status,
+            "created_at": (
+                self.created_at.isoformat() if self.created_at else None
+            ),
+        }

--- a/backend/app/domain/repositories/incident_repository.py
+++ b/backend/app/domain/repositories/incident_repository.py
@@ -1,0 +1,55 @@
+"""
+Repository interface for Incidents.
+
+Defines the contract that any incident data source must implement.
+This follows the same pattern as auth_repository.py.
+"""
+
+from abc import ABC, abstractmethod
+
+from app.domain.entities.incident import (
+    Incident,
+    IncidentSeverity,
+    IncidentType,
+)
+
+
+class IncidentRepository(ABC):
+    """Abstract repository interface for incident operations."""
+
+    @abstractmethod
+    async def create_incident(
+        self,
+        driver_id: str,
+        incident_type: IncidentType,
+        severity: IncidentSeverity,
+        description: str,
+    ) -> Incident:
+        """
+        Create a new incident report.
+
+        Args:
+            driver_id: ID of the driver reporting the incident
+            incident_type: Type of incident
+            severity: Severity level
+            description: Description of the incident
+
+        Returns:
+            The created Incident entity
+        """
+        pass
+
+    @abstractmethod
+    async def get_incidents_by_driver(
+        self, driver_id: str
+    ) -> list[Incident]:
+        """
+        Get all incidents reported by a specific driver.
+
+        Args:
+            driver_id: ID of the driver
+
+        Returns:
+            List of Incident entities
+        """
+        pass

--- a/backend/app/domain/usecases/incident_usecases.py
+++ b/backend/app/domain/usecases/incident_usecases.py
@@ -1,0 +1,73 @@
+"""
+Use cases for Incident operations.
+
+These contain the business logic for creating and retrieving incidents.
+Follows the same pattern as auth_usecases.py.
+"""
+
+from app.domain.entities.incident import (
+    Incident,
+    IncidentSeverity,
+    IncidentType,
+)
+from app.domain.repositories.incident_repository import IncidentRepository
+
+
+class CreateIncidentUseCase:
+    """Use case for creating a new incident report."""
+
+    def __init__(self, incident_repository: IncidentRepository) -> None:
+        self.incident_repository = incident_repository
+
+    async def execute(
+        self,
+        driver_id: str,
+        incident_type: IncidentType,
+        severity: IncidentSeverity,
+        description: str,
+    ) -> Incident:
+        """
+        Create a new incident.
+
+        Args:
+            driver_id: ID of the driver reporting
+            incident_type: Type of incident
+            severity: Severity level
+            description: Description of the incident
+
+        Returns:
+            The created Incident entity
+
+        Raises:
+            ValueError: If description is empty
+        """
+        if not description or not description.strip():
+            raise ValueError("Incident description is required")
+
+        return await self.incident_repository.create_incident(
+            driver_id=driver_id,
+            incident_type=incident_type,
+            severity=severity,
+            description=description.strip(),
+        )
+
+
+class GetDriverIncidentsUseCase:
+    """Use case for retrieving all incidents for a driver."""
+
+    def __init__(self, incident_repository: IncidentRepository) -> None:
+        self.incident_repository = incident_repository
+
+    async def execute(self, driver_id: str) -> list[Incident]:
+        """
+        Get all incidents reported by a driver.
+
+        Args:
+            driver_id: ID of the driver
+
+        Returns:
+            List of Incident entities
+        """
+        return await self.incident_repository.get_incidents_by_driver(
+            driver_id
+        )

--- a/backend/app/infrastructure/database/models.py
+++ b/backend/app/infrastructure/database/models.py
@@ -116,3 +116,52 @@ class RoleModel(Base):
 
     def __repr__(self) -> str:
         return f"<Role(id={self.id}, name='{self.name}')>"
+
+
+class IncidentModel(Base):
+    """
+    Incident database model.
+
+    Represents an incident reported by a driver.
+    Examples: vehicle breakdown, accident, delay.
+    """
+
+    __tablename__ = "incidents"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    driver_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    type: Mapped[str] = mapped_column(
+        String(50), nullable=False
+    )  # breakdown, accident, delay
+    severity: Mapped[str] = mapped_column(
+        String(50), nullable=False
+    )  # low, medium, high, critical
+    description: Mapped[str] = mapped_column(String(1000), nullable=False)
+    status: Mapped[str] = mapped_column(
+        String(50), default="open", nullable=False
+    )  # open, acknowledged, resolved
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime,
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow,
+        nullable=False,
+    )
+
+    # Relationships
+    driver: Mapped["UserModel"] = relationship(
+        "UserModel", foreign_keys=[driver_id], lazy="joined"
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<Incident(id={self.id}, type='{self.type}', "
+            f"severity='{self.severity}', status='{self.status}')>"
+        )

--- a/backend/app/infrastructure/repositories/database_incident_repository.py
+++ b/backend/app/infrastructure/repositories/database_incident_repository.py
@@ -1,0 +1,82 @@
+"""
+Database repository implementation for Incidents.
+
+Implements the IncidentRepository interface using SQLAlchemy.
+Follows the same pattern as database_auth_repository.py.
+"""
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.logger import Logger
+from app.domain.entities.incident import Incident
+from app.domain.repositories.incident_repository import (
+    IncidentRepository,
+    IncidentSeverity,
+    IncidentType,
+)
+from app.infrastructure.database.database import AsyncSessionLocal
+from app.infrastructure.database.models import IncidentModel
+
+
+class DatabaseIncidentRepository(IncidentRepository):
+    """SQLAlchemy implementation of IncidentRepository."""
+
+    async def create_incident(
+        self,
+        driver_id: str,
+        incident_type: IncidentType,
+        severity: IncidentSeverity,
+        description: str,
+    ) -> Incident:
+        """Create a new incident in the database."""
+        async with AsyncSessionLocal() as db:
+            incident_model = IncidentModel(
+                driver_id=int(driver_id),
+                type=incident_type,
+                severity=severity,
+                description=description,
+                status="open",
+            )
+            db.add(incident_model)
+            await db.commit()
+            await db.refresh(incident_model)
+
+            Logger.info(
+                f"Created incident: id={incident_model.id}, "
+                f"type={incident_type}, driver_id={driver_id}"
+            )
+
+            return self._to_entity(incident_model)
+
+    async def get_incidents_by_driver(
+        self, driver_id: str
+    ) -> list[Incident]:
+        """Get all incidents for a specific driver."""
+        async with AsyncSessionLocal() as db:
+            result = await db.execute(
+                select(IncidentModel)
+                .where(IncidentModel.driver_id == int(driver_id))
+                .order_by(IncidentModel.created_at.desc())
+            )
+            incidents = result.scalars().all()
+
+            Logger.info(
+                f"Retrieved {len(incidents)} incidents "
+                f"for driver_id={driver_id}"
+            )
+
+            return [self._to_entity(i) for i in incidents]
+
+    @staticmethod
+    def _to_entity(model: IncidentModel) -> Incident:
+        """Convert a database model to a domain entity."""
+        return Incident(
+            id=str(model.id),
+            driver_id=str(model.driver_id),
+            type=model.type,
+            severity=model.severity,
+            description=model.description,
+            status=model.status,
+            created_at=model.created_at,
+        )

--- a/backend/app/infrastructure/repositories/database_incident_repository.py
+++ b/backend/app/infrastructure/repositories/database_incident_repository.py
@@ -6,7 +6,6 @@ Follows the same pattern as database_auth_repository.py.
 """
 
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.logger import Logger
 from app.domain.entities.incident import Incident

--- a/mobile/src/core/config/dashboard.ts
+++ b/mobile/src/core/config/dashboard.ts
@@ -50,4 +50,14 @@ export const DASHBOARD_CONFIG = {
             { id: 7, title: 'Conduct', icon: 'alert-circle', color: ColorPalettes.amber[500] },
         ] as QuickAction[],
     },
+    driver: {
+        quickActions: [
+            { id: 1, title: 'Report Incident', icon: 'warning', color: ColorPalettes.red[500] },
+            { id: 2, title: 'Incident History', icon: 'list', color: ColorPalettes.blue[500] },
+            { id: 3, title: 'My Route', icon: 'map', color: ColorPalettes.emerald[500] },
+            { id: 4, title: 'Vehicle Status', icon: 'car', color: ColorPalettes.amber[500] },
+            { id: 5, title: 'Schedule', icon: 'calendar', color: ColorPalettes.indigo[500] },
+            { id: 6, title: 'Messages', icon: 'chatbubbles', color: ColorPalettes.pink[500] },
+        ] as QuickAction[],
+    },
 };

--- a/mobile/src/data/repositories/incident-repository-impl.ts
+++ b/mobile/src/data/repositories/incident-repository-impl.ts
@@ -1,0 +1,43 @@
+/**
+ * Implementation of IncidentRepository using the API client.
+ *
+ * Follows the same pattern as auth-repository-impl.ts and
+ * user-repository-impl.ts, including offline fallbacks.
+ */
+
+import { api } from '@/core/api-client';
+import { Logger } from '@/core/logger';
+import { Incident, IncidentSeverity, IncidentType } from '@/domain/entities/incident';
+import { IncidentRepository } from '@/domain/repositories/incident-repository';
+
+export class IncidentRepositoryImpl implements IncidentRepository {
+    async createIncident(
+        type: IncidentType,
+        severity: IncidentSeverity,
+        description: string,
+    ): Promise<Incident> {
+        try {
+            const response = await api.post('/incidents', {
+                type,
+                severity,
+                description,
+            });
+            return response.data;
+        } catch (error) {
+            Logger.error('Failed to create incident', error);
+            throw error;
+        }
+    }
+
+    async getDriverIncidents(): Promise<Incident[]> {
+        try {
+            const response = await api.get('/incidents');
+            return response.data.incidents;
+        } catch (error) {
+            Logger.error('Failed to fetch incidents', error);
+
+            // Fallback for demo stability
+            return [];
+        }
+    }
+}

--- a/mobile/src/domain/entities/incident.ts
+++ b/mobile/src/domain/entities/incident.ts
@@ -1,0 +1,20 @@
+/**
+ * Incident entity.
+ *
+ * Represents an incident reported by a driver,
+ * such as a vehicle breakdown, accident, or delay.
+ */
+
+export type IncidentType = 'breakdown' | 'accident' | 'delay';
+export type IncidentSeverity = 'low' | 'medium' | 'high' | 'critical';
+export type IncidentStatus = 'open' | 'acknowledged' | 'resolved';
+
+export interface Incident {
+    id: string;
+    driver_id: string;
+    type: IncidentType;
+    severity: IncidentSeverity;
+    description: string;
+    status: IncidentStatus;
+    created_at?: string;
+}

--- a/mobile/src/domain/entities/user.ts
+++ b/mobile/src/domain/entities/user.ts
@@ -2,6 +2,6 @@ export interface User {
     id: string;
     name: string;
     email: string;
-    role: 'admin' | 'student' | 'teacher' | 'parent';
+    role: 'admin' | 'student' | 'teacher' | 'parent' | 'driver';
     avatarUrl?: string;
 }

--- a/mobile/src/domain/repositories/incident-repository.ts
+++ b/mobile/src/domain/repositories/incident-repository.ts
@@ -1,0 +1,18 @@
+/**
+ * Repository interface for Incidents.
+ *
+ * Defines the contract that any incident data source must implement.
+ * Follows the same pattern as auth-repository.ts and user-repository.ts.
+ */
+
+import { Incident, IncidentSeverity, IncidentType } from '../entities/incident';
+
+export interface IncidentRepository {
+    createIncident(
+        type: IncidentType,
+        severity: IncidentSeverity,
+        description: string,
+    ): Promise<Incident>;
+
+    getDriverIncidents(): Promise<Incident[]>;
+}

--- a/mobile/src/domain/usecases/create-incident-usecase.ts
+++ b/mobile/src/domain/usecases/create-incident-usecase.ts
@@ -1,0 +1,26 @@
+/**
+ * Use case for creating a new incident report.
+ *
+ * Validates the input and delegates to the repository.
+ * Follows the same pattern as login-usecase.ts.
+ */
+
+import { ValidationError } from '@/core/error';
+import { Incident, IncidentSeverity, IncidentType } from '../entities/incident';
+import { IncidentRepository } from '../repositories/incident-repository';
+
+export class CreateIncidentUseCase {
+    constructor(private incidentRepository: IncidentRepository) { }
+
+    async execute(
+        type: IncidentType,
+        severity: IncidentSeverity,
+        description: string,
+    ): Promise<Incident> {
+        if (!description || !description.trim()) {
+            throw new ValidationError('Incident description is required');
+        }
+
+        return this.incidentRepository.createIncident(type, severity, description.trim());
+    }
+}

--- a/mobile/src/domain/usecases/get-driver-incidents-usecase.ts
+++ b/mobile/src/domain/usecases/get-driver-incidents-usecase.ts
@@ -1,0 +1,16 @@
+/**
+ * Use case for retrieving all incidents for a driver.
+ *
+ * Follows the same pattern as get-dashboard-data-usecase.ts.
+ */
+
+import { Incident } from '../entities/incident';
+import { IncidentRepository } from '../repositories/incident-repository';
+
+export class GetDriverIncidentsUseCase {
+    constructor(private incidentRepository: IncidentRepository) { }
+
+    async execute(): Promise<Incident[]> {
+        return this.incidentRepository.getDriverIncidents();
+    }
+}

--- a/mobile/src/presentation/hooks/useIncidents.ts
+++ b/mobile/src/presentation/hooks/useIncidents.ts
@@ -1,0 +1,73 @@
+/**
+ * Custom hook for managing incident state.
+ *
+ * Handles loading, submitting, error states, and the list of incidents.
+ * Follows the same pattern as useDashboard.ts.
+ */
+
+import { IncidentRepositoryImpl } from '@/data/repositories/incident-repository-impl';
+import { Incident, IncidentSeverity, IncidentType } from '@/domain/entities/incident';
+import { CreateIncidentUseCase } from '@/domain/usecases/create-incident-usecase';
+import { GetDriverIncidentsUseCase } from '@/domain/usecases/get-driver-incidents-usecase';
+import { useEffect, useState } from 'react';
+import { useAuth } from './useAuth';
+
+const incidentRepository = new IncidentRepositoryImpl();
+const createIncidentUseCase = new CreateIncidentUseCase(incidentRepository);
+const getDriverIncidentsUseCase = new GetDriverIncidentsUseCase(incidentRepository);
+
+export function useIncidents() {
+    const { user } = useAuth();
+    const [incidents, setIncidents] = useState<Incident[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [submitting, setSubmitting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (user) {
+            fetchIncidents();
+        }
+    }, [user]);
+
+    const fetchIncidents = async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const data = await getDriverIncidentsUseCase.execute();
+            setIncidents(data);
+        } catch (e) {
+            setError('Failed to load incidents');
+            console.error(e);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const createIncident = async (
+        type: IncidentType,
+        severity: IncidentSeverity,
+        description: string,
+    ) => {
+        setSubmitting(true);
+        setError(null);
+        try {
+            const newIncident = await createIncidentUseCase.execute(type, severity, description);
+            setIncidents((prev) => [newIncident, ...prev]);
+            return newIncident;
+        } catch (e: any) {
+            setError(e.message || 'Failed to create incident');
+            throw e;
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    return {
+        incidents,
+        loading,
+        submitting,
+        error,
+        createIncident,
+        refresh: fetchIncidents,
+    };
+}

--- a/mobile/src/presentation/screens/dashboards/DashboardSwitcher.tsx
+++ b/mobile/src/presentation/screens/dashboards/DashboardSwitcher.tsx
@@ -1,6 +1,7 @@
 import { useAuth } from '@/presentation/hooks/useAuth';
 import LoginScreen from '../LoginScreen';
 import AdminDashboard from './AdminDashboard';
+import DriverDashboard from './DriverDashboard';
 import ParentDashboard from './ParentDashboard';
 import StudentDashboard from './StudentDashboard';
 import TeacherDashboard from './TeacherDashboard';
@@ -21,6 +22,8 @@ export default function DashboardSwitcher() {
             return <ParentDashboard />;
         case 'student':
             return <StudentDashboard />;
+        case 'driver':
+            return <DriverDashboard />;
         default:
             return <LoginScreen />;
     }

--- a/mobile/src/presentation/screens/dashboards/DriverDashboard.tsx
+++ b/mobile/src/presentation/screens/dashboards/DriverDashboard.tsx
@@ -1,0 +1,560 @@
+import { DASHBOARD_CONFIG } from '@/core/config/dashboard';
+import { useTheme } from '@/core/theme/ThemeContext';
+import { QuickActionGrid } from '@/presentation/components/dashboard/QuickActionGrid';
+import { ThemedButton } from '@/presentation/components/ThemedButton';
+import { ThemedCard } from '@/presentation/components/ThemedCard';
+import { ThemedText } from '@/presentation/components/ThemedText';
+import { ThemedTextInput } from '@/presentation/components/ThemedTextInput';
+import { ThemedView } from '@/presentation/components/ThemedView';
+import { useAuth } from '@/presentation/hooks/useAuth';
+import { useDashboard } from '@/presentation/hooks/useDashboard';
+import { useIncidents } from '@/presentation/hooks/useIncidents';
+import { IncidentSeverity, IncidentType } from '@/domain/entities/incident';
+import { Ionicons } from '@expo/vector-icons';
+import React, { useState } from 'react';
+import {
+    Alert,
+    Dimensions,
+    RefreshControl,
+    ScrollView,
+    StatusBar,
+    StyleSheet,
+    TouchableOpacity,
+    View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+const { width } = Dimensions.get('window');
+
+// Options for the incident form pickers
+const INCIDENT_TYPES: { label: string; value: IncidentType; icon: string }[] = [
+    { label: 'Breakdown', value: 'breakdown', icon: 'build' },
+    { label: 'Accident', value: 'accident', icon: 'car' },
+    { label: 'Delay', value: 'delay', icon: 'time' },
+];
+
+const SEVERITY_LEVELS: { label: string; value: IncidentSeverity; color: string }[] = [
+    { label: 'Low', value: 'low', color: '#22c55e' },
+    { label: 'Medium', value: 'medium', color: '#f59e0b' },
+    { label: 'High', value: 'high', color: '#f97316' },
+    { label: 'Critical', value: 'critical', color: '#ef4444' },
+];
+
+export default function DriverDashboard() {
+    const { logout, user } = useAuth();
+    const { data: dashboardData, loading, refreshing, onRefresh } = useDashboard();
+    const {
+        incidents,
+        submitting,
+        createIncident,
+        refresh: refreshIncidents,
+    } = useIncidents();
+    const { theme, isDark } = useTheme();
+
+    // Form state
+    const [selectedType, setSelectedType] = useState<IncidentType>('breakdown');
+    const [selectedSeverity, setSelectedSeverity] = useState<IncidentSeverity>('medium');
+    const [description, setDescription] = useState('');
+    const [showForm, setShowForm] = useState(false);
+
+    const quickActions = DASHBOARD_CONFIG.driver.quickActions;
+
+    const getStatValue = (label: string, defaultValue: string = '0') => {
+        return dashboardData?.stats?.find(s => s.label === label)?.value || defaultValue;
+    };
+
+    const stats = [
+        { title: 'Total Incidents', value: getStatValue('Total Incidents'), icon: 'warning', color: '#fff' },
+        { title: 'Vehicle Status', value: getStatValue('Vehicle Status', 'Active'), icon: 'car', color: '#fff' },
+    ];
+
+    const handleSubmitIncident = async () => {
+        if (!description.trim()) {
+            Alert.alert('Validation Error', 'Please enter a description for the incident.');
+            return;
+        }
+
+        try {
+            await createIncident(selectedType, selectedSeverity, description);
+            Alert.alert('Success', 'Incident reported successfully!');
+            // Reset form
+            setDescription('');
+            setSelectedType('breakdown');
+            setSelectedSeverity('medium');
+            setShowForm(false);
+        } catch (e: any) {
+            Alert.alert('Error', e.message || 'Failed to report incident. Please try again.');
+        }
+    };
+
+    const handleRefresh = async () => {
+        await onRefresh();
+        await refreshIncidents();
+    };
+
+    const getSeverityColor = (severity: string) => {
+        switch (severity) {
+            case 'low': return '#22c55e';
+            case 'medium': return '#f59e0b';
+            case 'high': return '#f97316';
+            case 'critical': return '#ef4444';
+            default: return '#6b7280';
+        }
+    };
+
+    const getTypeIcon = (type: string) => {
+        switch (type) {
+            case 'breakdown': return 'build';
+            case 'accident': return 'car';
+            case 'delay': return 'time';
+            default: return 'alert-circle';
+        }
+    };
+
+    const getStatusColor = (status: string) => {
+        switch (status) {
+            case 'open': return '#3b82f6';
+            case 'acknowledged': return '#f59e0b';
+            case 'resolved': return '#22c55e';
+            default: return '#6b7280';
+        }
+    };
+
+    return (
+        <ThemedView style={styles.container}>
+            <StatusBar barStyle={isDark ? "light-content" : "light-content"} />
+            <ScrollView
+                style={styles.scrollView}
+                contentContainerStyle={styles.scrollContent}
+                refreshControl={<RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={theme.colors.primary} />}
+            >
+                {/* Blue Banner Header */}
+                <View style={[styles.banner, { backgroundColor: theme.colors.primary }]}>
+                    <SafeAreaView edges={['top']}>
+                        <View style={styles.headerContent}>
+                            <View>
+                                <ThemedText style={styles.userName} type="title" color="primaryForeground">
+                                    {user?.name || 'Driver'}
+                                </ThemedText>
+                                <ThemedText style={styles.subtitle} color="primaryForeground">
+                                    Driver Dashboard
+                                </ThemedText>
+                            </View>
+                            <TouchableOpacity onPress={logout} style={styles.logoutIcon}>
+                                <Ionicons name="log-out-outline" size={24} color={theme.colors.primaryForeground} />
+                            </TouchableOpacity>
+                        </View>
+
+                        {/* Banner Stats */}
+                        <View style={styles.bannerStats}>
+                            {stats.map((stat, index) => (
+                                <View key={index} style={[styles.bannerStatCard, { backgroundColor: 'rgba(255,255,255,0.15)' }]}>
+                                    <View style={styles.statIconContainer}>
+                                        <Ionicons name={stat.icon as any} size={24} color={theme.colors.primaryForeground} />
+                                    </View>
+                                    <View>
+                                        <ThemedText style={styles.bannerStatValue} type="title" color="primaryForeground">{stat.value}</ThemedText>
+                                        <ThemedText style={styles.bannerStatTitle} color="primaryForeground">{stat.title}</ThemedText>
+                                    </View>
+                                </View>
+                            ))}
+                        </View>
+                    </SafeAreaView>
+                </View>
+
+                {/* Main Content */}
+                <View style={[styles.mainContent, { backgroundColor: theme.colors.background }]}>
+                    {/* Quick Actions */}
+                    <View style={styles.sectionHeader}>
+                        <ThemedText style={styles.sectionTitle} type="subtitle">Quick Actions</ThemedText>
+                    </View>
+
+                    <QuickActionGrid actions={quickActions} />
+
+                    {/* Report Incident Section */}
+                    <View style={styles.sectionHeader}>
+                        <ThemedText style={styles.sectionTitle} type="subtitle">Report Incident</ThemedText>
+                        <TouchableOpacity
+                            onPress={() => setShowForm(!showForm)}
+                            style={[styles.toggleButton, { backgroundColor: theme.colors.primary }]}
+                        >
+                            <Ionicons name={showForm ? 'chevron-up' : 'add'} size={20} color={theme.colors.primaryForeground} />
+                        </TouchableOpacity>
+                    </View>
+
+                    {showForm && (
+                        <ThemedCard style={styles.formCard}>
+                            {/* Incident Type Picker */}
+                            <ThemedText style={styles.formLabel}>Incident Type</ThemedText>
+                            <View style={styles.optionRow}>
+                                {INCIDENT_TYPES.map((type) => (
+                                    <TouchableOpacity
+                                        key={type.value}
+                                        style={[
+                                            styles.optionChip,
+                                            {
+                                                backgroundColor: selectedType === type.value
+                                                    ? theme.colors.primary
+                                                    : theme.colors.secondary,
+                                                borderColor: selectedType === type.value
+                                                    ? theme.colors.primary
+                                                    : theme.colors.border,
+                                            },
+                                        ]}
+                                        onPress={() => setSelectedType(type.value)}
+                                    >
+                                        <Ionicons
+                                            name={type.icon as any}
+                                            size={16}
+                                            color={selectedType === type.value ? theme.colors.primaryForeground : theme.colors.foreground}
+                                        />
+                                        <ThemedText
+                                            style={[
+                                                styles.optionChipText,
+                                                {
+                                                    color: selectedType === type.value
+                                                        ? theme.colors.primaryForeground
+                                                        : theme.colors.foreground,
+                                                },
+                                            ]}
+                                        >
+                                            {type.label}
+                                        </ThemedText>
+                                    </TouchableOpacity>
+                                ))}
+                            </View>
+
+                            {/* Severity Picker */}
+                            <ThemedText style={styles.formLabel}>Severity</ThemedText>
+                            <View style={styles.optionRow}>
+                                {SEVERITY_LEVELS.map((level) => (
+                                    <TouchableOpacity
+                                        key={level.value}
+                                        style={[
+                                            styles.severityChip,
+                                            {
+                                                backgroundColor: selectedSeverity === level.value
+                                                    ? level.color
+                                                    : level.color + '15',
+                                                borderColor: level.color,
+                                                borderWidth: selectedSeverity === level.value ? 0 : 1,
+                                            },
+                                        ]}
+                                        onPress={() => setSelectedSeverity(level.value)}
+                                    >
+                                        <ThemedText
+                                            style={[
+                                                styles.severityChipText,
+                                                {
+                                                    color: selectedSeverity === level.value
+                                                        ? '#fff'
+                                                        : level.color,
+                                                },
+                                            ]}
+                                        >
+                                            {level.label}
+                                        </ThemedText>
+                                    </TouchableOpacity>
+                                ))}
+                            </View>
+
+                            {/* Description Input */}
+                            <ThemedTextInput
+                                label="Description"
+                                placeholder="Describe the incident..."
+                                value={description}
+                                onChangeText={setDescription}
+                                multiline
+                                numberOfLines={4}
+                                style={styles.descriptionInput}
+                            />
+
+                            {/* Submit Button */}
+                            <ThemedButton
+                                title={submitting ? 'Submitting...' : 'Submit Report'}
+                                onPress={handleSubmitIncident}
+                                disabled={submitting || !description.trim()}
+                            />
+                        </ThemedCard>
+                    )}
+
+                    {/* Incident History */}
+                    <View style={styles.sectionHeader}>
+                        <ThemedText style={styles.sectionTitle} type="subtitle">Incident History</ThemedText>
+                        {incidents.length > 0 && (
+                            <View style={[styles.badge, { backgroundColor: theme.colors.primary }]}>
+                                <ThemedText style={styles.badgeText} color="primaryForeground">
+                                    {incidents.length}
+                                </ThemedText>
+                            </View>
+                        )}
+                    </View>
+
+                    {incidents.length === 0 ? (
+                        <ThemedCard style={styles.emptyCard}>
+                            <View style={styles.emptyContent}>
+                                <Ionicons name="checkmark-circle-outline" size={48} color={theme.colors.mutedForeground} />
+                                <ThemedText style={styles.emptyText} lightColor="#666" darkColor="#999">
+                                    No incidents reported yet
+                                </ThemedText>
+                            </View>
+                        </ThemedCard>
+                    ) : (
+                        <ThemedCard style={styles.historyCard} padding={0}>
+                            {incidents.map((incident, index) => (
+                                <View
+                                    key={incident.id}
+                                    style={[
+                                        styles.incidentItem,
+                                        index !== incidents.length - 1 && {
+                                            borderBottomWidth: 1,
+                                            borderBottomColor: theme.colors.border,
+                                        },
+                                    ]}
+                                >
+                                    <View style={[styles.incidentIcon, { backgroundColor: getSeverityColor(incident.severity) + '15' }]}>
+                                        <Ionicons
+                                            name={getTypeIcon(incident.type) as any}
+                                            size={20}
+                                            color={getSeverityColor(incident.severity)}
+                                        />
+                                    </View>
+                                    <View style={styles.incidentContent}>
+                                        <ThemedText style={styles.incidentType} type="defaultSemiBold">
+                                            {incident.type.charAt(0).toUpperCase() + incident.type.slice(1)}
+                                        </ThemedText>
+                                        <ThemedText style={styles.incidentDescription} lightColor="#666" darkColor="#999" numberOfLines={2}>
+                                            {incident.description}
+                                        </ThemedText>
+                                        <View style={styles.incidentMeta}>
+                                            <View style={[styles.statusBadge, { backgroundColor: getStatusColor(incident.status) + '20' }]}>
+                                                <ThemedText style={[styles.statusText, { color: getStatusColor(incident.status) }]}>
+                                                    {incident.status.charAt(0).toUpperCase() + incident.status.slice(1)}
+                                                </ThemedText>
+                                            </View>
+                                            <View style={[styles.severityBadge, { backgroundColor: getSeverityColor(incident.severity) + '20' }]}>
+                                                <ThemedText style={[styles.severityText, { color: getSeverityColor(incident.severity) }]}>
+                                                    {incident.severity.charAt(0).toUpperCase() + incident.severity.slice(1)}
+                                                </ThemedText>
+                                            </View>
+                                        </View>
+                                    </View>
+                                </View>
+                            ))}
+                        </ThemedCard>
+                    )}
+
+                    {/* Bottom spacing */}
+                    <View style={{ height: 40 }} />
+                </View>
+            </ScrollView>
+        </ThemedView>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+    },
+    scrollView: {
+        flex: 1,
+    },
+    scrollContent: {
+        flexGrow: 1,
+    },
+    banner: {
+        paddingBottom: 30,
+        borderBottomLeftRadius: 32,
+        borderBottomRightRadius: 32,
+    },
+    headerContent: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        paddingHorizontal: 24,
+        paddingTop: 20,
+        paddingBottom: 24,
+    },
+    userName: {
+        fontSize: 28,
+        fontWeight: '700',
+    },
+    subtitle: {
+        fontSize: 16,
+        marginTop: 4,
+    },
+    logoutIcon: {
+        padding: 8,
+    },
+    bannerStats: {
+        flexDirection: 'row',
+        paddingHorizontal: 20,
+        gap: 12,
+    },
+    bannerStatCard: {
+        flex: 1,
+        flexDirection: 'row',
+        alignItems: 'center',
+        padding: 16,
+        borderRadius: 20,
+        gap: 12,
+    },
+    statIconContainer: {
+        width: 44,
+        height: 44,
+        borderRadius: 22,
+        backgroundColor: 'rgba(255,255,255,0.2)',
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    bannerStatValue: {
+        fontSize: 22,
+        fontWeight: '700',
+    },
+    bannerStatTitle: {
+        fontSize: 12,
+    },
+    mainContent: {
+        flex: 1,
+        marginTop: 0,
+        borderTopLeftRadius: 32,
+        borderTopRightRadius: 32,
+        paddingHorizontal: 24,
+        paddingTop: 32,
+    },
+    sectionHeader: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        marginBottom: 20,
+    },
+    sectionTitle: {
+        fontSize: 20,
+        fontWeight: '700',
+        flex: 1,
+    },
+    toggleButton: {
+        width: 32,
+        height: 32,
+        borderRadius: 16,
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    badge: {
+        paddingHorizontal: 10,
+        paddingVertical: 4,
+        borderRadius: 12,
+        marginLeft: 12,
+    },
+    badgeText: {
+        color: '#fff',
+        fontSize: 12,
+        fontWeight: '600',
+    },
+    formCard: {
+        borderRadius: 24,
+        marginBottom: 32,
+        padding: 20,
+    },
+    formLabel: {
+        fontSize: 14,
+        fontWeight: '600',
+        marginBottom: 10,
+        marginTop: 4,
+    },
+    optionRow: {
+        flexDirection: 'row',
+        flexWrap: 'wrap',
+        gap: 10,
+        marginBottom: 20,
+    },
+    optionChip: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        paddingHorizontal: 14,
+        paddingVertical: 10,
+        borderRadius: 12,
+        gap: 6,
+        borderWidth: 1,
+    },
+    optionChipText: {
+        fontSize: 13,
+        fontWeight: '600',
+    },
+    severityChip: {
+        paddingHorizontal: 14,
+        paddingVertical: 10,
+        borderRadius: 12,
+    },
+    severityChipText: {
+        fontSize: 13,
+        fontWeight: '600',
+    },
+    descriptionInput: {
+        height: 100,
+        textAlignVertical: 'top',
+        paddingTop: 12,
+    },
+    historyCard: {
+        borderRadius: 24,
+        overflow: 'hidden',
+        marginBottom: 16,
+    },
+    emptyCard: {
+        borderRadius: 24,
+        marginBottom: 16,
+    },
+    emptyContent: {
+        alignItems: 'center',
+        paddingVertical: 32,
+        gap: 12,
+    },
+    emptyText: {
+        fontSize: 14,
+    },
+    incidentItem: {
+        flexDirection: 'row',
+        alignItems: 'flex-start',
+        padding: 16,
+    },
+    incidentIcon: {
+        width: 48,
+        height: 48,
+        borderRadius: 14,
+        justifyContent: 'center',
+        alignItems: 'center',
+        marginRight: 16,
+    },
+    incidentContent: {
+        flex: 1,
+    },
+    incidentType: {
+        fontSize: 15,
+        marginBottom: 2,
+    },
+    incidentDescription: {
+        fontSize: 13,
+        marginBottom: 8,
+    },
+    incidentMeta: {
+        flexDirection: 'row',
+        gap: 8,
+    },
+    statusBadge: {
+        paddingHorizontal: 8,
+        paddingVertical: 3,
+        borderRadius: 8,
+    },
+    statusText: {
+        fontSize: 11,
+        fontWeight: '600',
+    },
+    severityBadge: {
+        paddingHorizontal: 8,
+        paddingVertical: 3,
+        borderRadius: 8,
+    },
+    severityText: {
+        fontSize: 11,
+        fontWeight: '600',
+    },
+});


### PR DESCRIPTION
## Feature: Driver Incident Submission Interface

This PR adds the ability for drivers to report vehicle incidents (Breakdown, Accident, Delay) from their dashboard and view a history of past incidents.

### What's included

**Backend**
- `POST /api/v1/incidents` — Report a new incident
- `GET /api/v1/incidents` — View incident history
- Incident database model, schemas, and use cases
- Driver dashboard stats

**Mobile**
- New Driver Dashboard screen with incident report form and history list
- Incident type, severity, and description input
- Added `driver` role support across the app

### How to Test
1. Restart the backend to create the new `incidents` table
2. Login as `driver@myuser.com` / `driver123`
3. Tap **+** next to "Report Incident" to open the form
4. Fill in details and submit
5. Incident appears in the history below