### PR TITLE
feat: implement personal fee status and ledger (#352)

### DIFF
--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -135,7 +135,6 @@ class DashboardResponse(BaseModel):
     stats: list[StatItem]
 
 
-<<<<<<< HEAD
 class SubjectInput(BaseModel):
     """Schema for subject input when updating class subjects."""
 
@@ -200,7 +199,7 @@ class PaymentCreate(BaseModel):
                     "amount": 5000.00,
                     "payment_mode": "UPI",
                     "reference_number": "UPI123456789",
-                    "remarks": "Monthly fee \u2013 April",
+                    "remarks": "Monthly fee – April",
                 }
             ]
         }
@@ -234,15 +233,15 @@ class StudentResponse(BaseModel):
     next_due_date: Optional[datetime] = None
 
     model_config = {"from_attributes": True}
-=======
-# Fee Management Schemas
->>>>>>> 6057939 (feat: implement personal fee status and ledger (#352))
 
+
+# ------------------------------------------------------------------ #
+# Fee Management Schemas
+# ------------------------------------------------------------------ #
 
 class FeeStructureResponse(BaseModel):
     """Response schema for fee structure data."""
 
-<<<<<<< HEAD
     id: int
     student_id: int
     total_fee: float
@@ -281,7 +280,7 @@ class PaymentResponse(BaseModel):
                     "payment_mode": "UPI",
                     "reference_number": "UPI123456789",
                     "status": "Paid",
-                    "remarks": "Monthly fee \u2013 April",
+                    "remarks": "Monthly fee – April",
                     "payment_date": "2024-04-01T10:00:00",
                 }
             ]
@@ -298,28 +297,6 @@ class PaymentSummaryResponse(BaseModel):
     total_overdue: float
 
     model_config = {"from_attributes": True}
-=======
-    id: str
-    student_id: str
-    fee_head: str
-    total_amount: float
-    is_mandatory: bool
-    academic_year: str
-
-    model_config = {
-        "json_schema_extra": {
-            "examples": [
-                {
-                    "id": "fs-001",
-                    "student_id": "std-123",
-                    "fee_head": "Tuition Fee",
-                    "total_amount": 50000.0,
-                    "is_mandatory": True,
-                    "academic_year": "2024-2025",
-                }
-            ]
-        }
-    }
 
 
 class FeeSummaryResponse(BaseModel):
@@ -408,4 +385,3 @@ class TransactionResponse(BaseModel):
             ]
         }
     }
->>>>>>> 6057939 (feat: implement personal fee status and ledger (#352))

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -16,12 +16,12 @@ class LoginRequest(BaseModel):
     email: EmailStr
     password: str = Field(
         ..., min_length=6, description="User password (minimum 6 characters)"
-        )
+    )
 
     model_config = {
         "json_schema_extra": {
             "examples": [{"email": "admin@myuser.com", "password": "admin123"}]
-            }
+        }
     }
 
 
@@ -31,7 +31,7 @@ class RoleResponse(BaseModel):
     id: str
     name: Literal[
         "admin", "teacher", "student", "parent", "transport", "driver"
-        ]
+    ]
     description: str | None = None
 
 
@@ -43,7 +43,7 @@ class UserResponse(BaseModel):
     email: str
     role: Literal[
         "admin", "teacher", "student", "parent", "transport", "driver"
-        ]
+    ]
     roles: list[RoleResponse]
     avatarUrl: str | None = None
 
@@ -102,7 +102,7 @@ class ErrorResponse(BaseModel):
 
     model_config = {
         "json_schema_extra": {"examples": [{"detail": "Error message"}]}
-        }
+    }
 
 
 class DemoCredential(BaseModel):
@@ -206,7 +206,9 @@ class PaymentCreate(BaseModel):
     }
 
     @model_validator(mode="after")
-    def validate_reference_number_for_digital_payments(self) -> "PaymentCreate":
+    def validate_reference_number_for_digital_payments(
+        self,
+    ) -> "PaymentCreate":
         """
         Ensure a reference number is supplied for UPI or Card payments.
 
@@ -218,7 +220,7 @@ class PaymentCreate(BaseModel):
             self.reference_number and self.reference_number.strip()
         ):
             raise ValueError(
-                f"reference_number is required for {self.payment_mode} payments."
+                f"reference_number is required for {self.payment_mode}."
             )
         return self
 
@@ -238,6 +240,7 @@ class StudentResponse(BaseModel):
 # ------------------------------------------------------------------ #
 # Fee Management Schemas
 # ------------------------------------------------------------------ #
+
 
 class FeeStructureResponse(BaseModel):
     """Response schema for fee structure data."""

--- a/backend/app/api/schemas.py
+++ b/backend/app/api/schemas.py
@@ -135,6 +135,7 @@ class DashboardResponse(BaseModel):
     stats: list[StatItem]
 
 
+<<<<<<< HEAD
 class SubjectInput(BaseModel):
     """Schema for subject input when updating class subjects."""
 
@@ -233,11 +234,15 @@ class StudentResponse(BaseModel):
     next_due_date: Optional[datetime] = None
 
     model_config = {"from_attributes": True}
+=======
+# Fee Management Schemas
+>>>>>>> 6057939 (feat: implement personal fee status and ledger (#352))
 
 
 class FeeStructureResponse(BaseModel):
     """Response schema for fee structure data."""
 
+<<<<<<< HEAD
     id: int
     student_id: int
     total_fee: float
@@ -293,3 +298,114 @@ class PaymentSummaryResponse(BaseModel):
     total_overdue: float
 
     model_config = {"from_attributes": True}
+=======
+    id: str
+    student_id: str
+    fee_head: str
+    total_amount: float
+    is_mandatory: bool
+    academic_year: str
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "id": "fs-001",
+                    "student_id": "std-123",
+                    "fee_head": "Tuition Fee",
+                    "total_amount": 50000.0,
+                    "is_mandatory": True,
+                    "academic_year": "2024-2025",
+                }
+            ]
+        }
+    }
+
+
+class FeeSummaryResponse(BaseModel):
+    """Response schema for aggregated fee summary."""
+
+    student_id: str
+    total_fee: float
+    paid_amount: float
+    balance_due: float
+    next_due_date: datetime | None = None
+    status_percentage: float = Field(
+        ..., ge=0, le=100, description="Percentage of fees paid (0-100)"
+    )
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "student_id": "std-123",
+                    "total_fee": 100000.0,
+                    "paid_amount": 50000.0,
+                    "balance_due": 50000.0,
+                    "next_due_date": "2024-05-15T00:00:00",
+                    "status_percentage": 50.0,
+                }
+            ]
+        }
+    }
+
+
+class InstallmentResponse(BaseModel):
+    """Response schema for fee installment data."""
+
+    id: str
+    fee_structure_id: str
+    student_id: str
+    due_date: datetime
+    amount: float
+    status: Literal["Pending", "Paid", "Overdue"]
+    paid_date: datetime | None = None
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "id": "inst-001",
+                    "fee_structure_id": "fs-001",
+                    "student_id": "std-123",
+                    "due_date": "2024-04-15T00:00:00",
+                    "amount": 25000.0,
+                    "status": "Paid",
+                    "paid_date": "2024-04-10T10:30:00",
+                }
+            ]
+        }
+    }
+
+
+class TransactionResponse(BaseModel):
+    """Response schema for transaction/receipt data."""
+
+    id: str
+    student_id: str
+    installment_id: str | None = None
+    amount: float
+    payment_mode: Literal["UPI", "Card", "Cash", "Check", "Online"]
+    transaction_ref: str
+    receipt_number: str
+    created_at: datetime
+    description: str | None = None
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "id": "txn-001",
+                    "student_id": "std-123",
+                    "installment_id": "inst-001",
+                    "amount": 25000.0,
+                    "payment_mode": "Online",
+                    "transaction_ref": "TXN123456789",
+                    "receipt_number": "REC-A1B2C3D4",
+                    "created_at": "2024-04-10T10:30:00",
+                    "description": "Payment for tuition fee",
+                }
+            ]
+        }
+    }
+>>>>>>> 6057939 (feat: implement personal fee status and ledger (#352))

--- a/backend/app/api/v1/endpoints/__init__.py
+++ b/backend/app/api/v1/endpoints/__init__.py
@@ -1,6 +1,7 @@
 """API v1 endpoints."""
 
-from app.api.v1.endpoints import auth, health
+from app.api.v1.endpoints import auth, health, dashboard, finance
 from .class_subjects import router as class_subjects_router
+from .payments import router as payments_router
 
-__all__ = ["auth", "health", "class_subjects_router"]
+__all__ = ["auth", "health", "dashboard", "finance", "class_subjects_router", "payments_router"]

--- a/backend/app/api/v1/endpoints/__init__.py
+++ b/backend/app/api/v1/endpoints/__init__.py
@@ -4,4 +4,11 @@ from app.api.v1.endpoints import auth, health, dashboard, finance
 from .class_subjects import router as class_subjects_router
 from .payments import router as payments_router
 
-__all__ = ["auth", "health", "dashboard", "finance", "class_subjects_router", "payments_router"]
+__all__ = [
+    "auth",
+    "health",
+    "dashboard",
+    "finance",
+    "class_subjects_router",
+    "payments_router",
+]

--- a/backend/app/api/v1/endpoints/class_subjects.py
+++ b/backend/app/api/v1/endpoints/class_subjects.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.infrastructure.database.database import get_db
 from app.infrastructure.repositories.class_repository import ClassRepository
 from app.infrastructure.repositories.subject_repository import (
-    SubjectRepository
+    SubjectRepository,
 )
 from app.domain.usecases.update_class_subjects import (
     UpdateClassSubjectsUseCase,

--- a/backend/app/api/v1/endpoints/dashboard.py
+++ b/backend/app/api/v1/endpoints/dashboard.py
@@ -12,8 +12,7 @@ router = APIRouter(prefix="/dashboard", tags=["Dashboard"])
     status_code=status.HTTP_200_OK,
     summary="Get dashboard statistics",
     description=(
-        "Retrieve dashboard statistics based on the "
-        "authenticated user's role."
+        "Retrieve dashboard statistics based on the authenticated user's role."
     ),
 )
 async def get_dashboard_stats(

--- a/backend/app/api/v1/endpoints/finance.py
+++ b/backend/app/api/v1/endpoints/finance.py
@@ -122,7 +122,7 @@ class DummyFeeRepository:
                 description="Tuition fee installment 1",
             ),
         ]
-        return transactions[offset:offset + limit]
+        return transactions[offset: offset + limit]
 
     async def get_transaction_by_receipt(self, receipt_number: str):
         from app.domain.entities.fee import Transaction
@@ -226,7 +226,8 @@ async def get_installments(
     Get installments for a student.
 
     Returns:
-        List[InstallmentResponse]: List of installments with due dates and status
+        List[InstallmentResponse]: List of installments with
+            due dates and status
     """
     repository = DummyFeeRepository()
     use_case = GetInstallmentsUseCaseImpl(repository)
@@ -263,7 +264,8 @@ async def get_receipts(
     Get transaction receipts for a student.
 
     Returns:
-        List[TransactionResponse]: List of paid transactions with receipt details
+        List[TransactionResponse]: List of paid transactions with
+            receipt details
     """
     repository = DummyFeeRepository()
     use_case = GetTransactionHistoryUseCaseImpl(repository)

--- a/backend/app/api/v1/endpoints/finance.py
+++ b/backend/app/api/v1/endpoints/finance.py
@@ -1,0 +1,329 @@
+from fastapi import APIRouter, Depends, status, Path, Query
+from app.api.dependencies import get_current_user
+from app.api.schemas import (
+    FeeSummaryResponse,
+    FeeStructureResponse,
+    InstallmentResponse,
+    TransactionResponse,
+)
+from app.domain.entities.user import User
+from app.domain.usecases.fee_usecases import (
+    GetFeeStructureUseCaseImpl,
+    GetFeeSummaryUseCaseImpl,
+    GetInstallmentsUseCaseImpl,
+    GetTransactionHistoryUseCaseImpl,
+    GetReceiptDetailsUseCaseImpl,
+)
+
+router = APIRouter(prefix="/finance", tags=["Finance & Fees"])
+
+
+# Dummy repository for demonstration (would be injected in real app)
+class DummyFeeRepository:
+    """Mock repository for fee operations."""
+
+    async def get_fee_structure(self, student_id: str):
+        from app.domain.entities.fee import FeeStructure
+
+        return [
+            FeeStructure(
+                id="fs-001",
+                student_id=student_id,
+                fee_head="Tuition Fee",
+                total_amount=50000.0,
+                is_mandatory=True,
+                academic_year="2024-2025",
+            ),
+            FeeStructure(
+                id="fs-002",
+                student_id=student_id,
+                fee_head="Transport Fee",
+                total_amount=15000.0,
+                is_mandatory=True,
+                academic_year="2024-2025",
+            ),
+            FeeStructure(
+                id="fs-003",
+                student_id=student_id,
+                fee_head="Lab Fee",
+                total_amount=5000.0,
+                is_mandatory=False,
+                academic_year="2024-2025",
+            ),
+        ]
+
+    async def get_fee_summary(self, student_id: str):
+        from app.domain.entities.fee import FeeSummary
+        from datetime import datetime, timedelta
+
+        return FeeSummary(
+            student_id=student_id,
+            total_fee=70000.0,
+            paid_amount=35000.0,
+            balance_due=35000.0,
+            next_due_date=datetime.now() + timedelta(days=15),
+            status_percentage=50.0,
+        )
+
+    async def get_installments(self, student_id: str, fee_structure_id=None):
+        from app.domain.entities.fee import Installment
+        from datetime import datetime, timedelta
+
+        installments = [
+            Installment(
+                id="inst-001",
+                fee_structure_id="fs-001",
+                student_id=student_id,
+                due_date=datetime(2024, 4, 15),
+                amount=25000.0,
+                status="Paid",
+                paid_date=datetime(2024, 4, 10),
+            ),
+            Installment(
+                id="inst-002",
+                fee_structure_id="fs-001",
+                student_id=student_id,
+                due_date=datetime(2024, 7, 15),
+                amount=25000.0,
+                status="Pending",
+            ),
+            Installment(
+                id="inst-003",
+                fee_structure_id="fs-002",
+                student_id=student_id,
+                due_date=datetime(2024, 5, 1),
+                amount=15000.0,
+                status="Pending",
+            ),
+        ]
+
+        if fee_structure_id:
+            return [
+                i
+                for i in installments
+                if i.fee_structure_id == fee_structure_id
+            ]
+        return installments
+
+    async def get_transactions(self, student_id: str, limit=20, offset=0):
+        from app.domain.entities.fee import Transaction
+        from datetime import datetime
+
+        transactions = [
+            Transaction(
+                id="txn-001",
+                student_id=student_id,
+                installment_id="inst-001",
+                amount=25000.0,
+                payment_mode="Online",
+                transaction_ref="TXN20240410001",
+                receipt_number="REC-A1B2C3D4",
+                created_at=datetime(2024, 4, 10, 10, 30),
+                description="Tuition fee installment 1",
+            ),
+        ]
+        return transactions[offset : offset + limit]
+
+    async def get_transaction_by_receipt(self, receipt_number: str):
+        from app.domain.entities.fee import Transaction
+        from datetime import datetime
+
+        if receipt_number == "REC-A1B2C3D4":
+            return Transaction(
+                id="txn-001",
+                student_id="std-123",
+                installment_id="inst-001",
+                amount=25000.0,
+                payment_mode="Online",
+                transaction_ref="TXN20240410001",
+                receipt_number=receipt_number,
+                created_at=datetime(2024, 4, 10, 10, 30),
+                description="Tuition fee installment 1",
+            )
+        return None
+
+
+@router.get(
+    "/student/{student_id}/fee-summary",
+    response_model=FeeSummaryResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Get student fee summary",
+    description="Retrieve aggregated fee summary for a student",
+)
+async def get_fee_summary(
+    student_id: str = Path(..., description="Student ID"),
+    current_user: User = Depends(get_current_user),
+) -> FeeSummaryResponse:
+    """
+    Get fee summary for a student.
+
+    Returns:
+        FeeSummaryResponse: Total fee, paid amount, balance due, and percentage
+    """
+    repository = DummyFeeRepository()
+    use_case = GetFeeSummaryUseCaseImpl(repository)
+    summary = await use_case.execute(student_id)
+
+    return FeeSummaryResponse(
+        student_id=summary.student_id,
+        total_fee=summary.total_fee,
+        paid_amount=summary.paid_amount,
+        balance_due=summary.balance_due,
+        next_due_date=summary.next_due_date,
+        status_percentage=summary.status_percentage,
+    )
+
+
+@router.get(
+    "/student/{student_id}/fee-structure",
+    response_model=list[FeeStructureResponse],
+    status_code=status.HTTP_200_OK,
+    summary="Get student fee structure",
+    description="Retrieve fee structure details for a student",
+)
+async def get_fee_structure(
+    student_id: str = Path(..., description="Student ID"),
+    current_user: User = Depends(get_current_user),
+) -> list[FeeStructureResponse]:
+    """
+    Get fee structure for a student.
+
+    Returns:
+        List[FeeStructureResponse]: List of fee components with amounts
+    """
+    repository = DummyFeeRepository()
+    use_case = GetFeeStructureUseCaseImpl(repository)
+    structures = await use_case.execute(student_id)
+
+    return [
+        FeeStructureResponse(
+            id=s.id,
+            student_id=s.student_id,
+            fee_head=s.fee_head,
+            total_amount=s.total_amount,
+            is_mandatory=s.is_mandatory,
+            academic_year=s.academic_year,
+        )
+        for s in structures
+    ]
+
+
+@router.get(
+    "/student/{student_id}/installments",
+    response_model=list[InstallmentResponse],
+    status_code=status.HTTP_200_OK,
+    summary="Get fee installments",
+    description="Retrieve all fee installments with payment status",
+)
+async def get_installments(
+    student_id: str = Path(..., description="Student ID"),
+    fee_structure_id: str | None = Query(
+        None, description="Optional fee structure filter"
+    ),
+    current_user: User = Depends(get_current_user),
+) -> list[InstallmentResponse]:
+    """
+    Get installments for a student.
+
+    Returns:
+        List[InstallmentResponse]: List of installments with due dates and status
+    """
+    repository = DummyFeeRepository()
+    use_case = GetInstallmentsUseCaseImpl(repository)
+    installments = await use_case.execute(student_id, fee_structure_id)
+
+    return [
+        InstallmentResponse(
+            id=i.id,
+            fee_structure_id=i.fee_structure_id,
+            student_id=i.student_id,
+            due_date=i.due_date,
+            amount=i.amount,
+            status=i.status,
+            paid_date=i.paid_date,
+        )
+        for i in installments
+    ]
+
+
+@router.get(
+    "/student/{student_id}/receipts",
+    response_model=list[TransactionResponse],
+    status_code=status.HTTP_200_OK,
+    summary="Get transaction receipts",
+    description="Retrieve transaction/receipt history for a student",
+)
+async def get_receipts(
+    student_id: str = Path(..., description="Student ID"),
+    limit: int = Query(20, ge=1, le=100, description="Limit per page"),
+    offset: int = Query(0, ge=0, description="Pagination offset"),
+    current_user: User = Depends(get_current_user),
+) -> list[TransactionResponse]:
+    """
+    Get transaction receipts for a student.
+
+    Returns:
+        List[TransactionResponse]: List of paid transactions with receipt details
+    """
+    repository = DummyFeeRepository()
+    use_case = GetTransactionHistoryUseCaseImpl(repository)
+    transactions = await use_case.execute(student_id, limit, offset)
+
+    return [
+        TransactionResponse(
+            id=t.id,
+            student_id=t.student_id,
+            installment_id=t.installment_id,
+            amount=t.amount,
+            payment_mode=t.payment_mode,
+            transaction_ref=t.transaction_ref,
+            receipt_number=t.receipt_number,
+            created_at=t.created_at,
+            description=t.description,
+        )
+        for t in transactions
+    ]
+
+
+@router.get(
+    "/receipt/{receipt_number}",
+    response_model=TransactionResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Get receipt details",
+    description="Retrieve detailed information for a specific receipt",
+)
+async def get_receipt_details(
+    receipt_number: str = Path(
+        ..., description="Receipt number (e.g., REC-A1B2C3D4)"
+    ),
+    current_user: User = Depends(get_current_user),
+) -> TransactionResponse:
+    """
+    Get receipt details by receipt number.
+
+    Returns:
+        TransactionResponse: Complete receipt and transaction details
+    """
+    repository = DummyFeeRepository()
+    use_case = GetReceiptDetailsUseCaseImpl(repository)
+    transaction = await use_case.execute(receipt_number)
+
+    if not transaction:
+        from fastapi import HTTPException
+
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Receipt {receipt_number} not found",
+        )
+
+    return TransactionResponse(
+        id=transaction.id,
+        student_id=transaction.student_id,
+        installment_id=transaction.installment_id,
+        amount=transaction.amount,
+        payment_mode=transaction.payment_mode,
+        transaction_ref=transaction.transaction_ref,
+        receipt_number=transaction.receipt_number,
+        created_at=transaction.created_at,
+        description=transaction.description,
+    )

--- a/backend/app/api/v1/endpoints/finance.py
+++ b/backend/app/api/v1/endpoints/finance.py
@@ -67,7 +67,7 @@ class DummyFeeRepository:
 
     async def get_installments(self, student_id: str, fee_structure_id=None):
         from app.domain.entities.fee import Installment
-        from datetime import datetime, timedelta
+        from datetime import datetime
 
         installments = [
             Installment(
@@ -122,7 +122,7 @@ class DummyFeeRepository:
                 description="Tuition fee installment 1",
             ),
         ]
-        return transactions[offset : offset + limit]
+        return transactions[offset:offset + limit]
 
     async def get_transaction_by_receipt(self, receipt_number: str):
         from app.domain.entities.fee import Transaction

--- a/backend/app/api/v1/endpoints/payments.py
+++ b/backend/app/api/v1/endpoints/payments.py
@@ -57,7 +57,10 @@ router = APIRouter(prefix="/payments", tags=["Payments"])
     responses={
         400: {"model": ErrorResponse, "description": "Validation error"},
         401: {"model": ErrorResponse, "description": "Unauthorized"},
-        404: {"model": ErrorResponse, "description": "Student or fee structure not found"},
+        404: {
+            "model": ErrorResponse,
+            "description": "Student or fee structure not found",
+        },
         500: {
             "model": ErrorResponse,
             "description": "Internal server error",
@@ -66,9 +69,11 @@ router = APIRouter(prefix="/payments", tags=["Payments"])
     summary="Record a payment",
     description=(
         "Record a new payment transaction for a student. "
-        "A unique receipt number (REC-YYYY-XXXX format) is generated automatically. "
-        "The payment status is derived from the amount vs. the outstanding balance: "
-        "'Paid' if the balance is cleared, 'Partial' otherwise. "
+        "A unique receipt number (REC-YYYY-XXXX format) is generated "
+        "automatically. "
+        "The payment status is derived from the amount vs. the "
+        "outstanding balance: 'Paid' if the balance is cleared, "
+        "'Partial' otherwise. "
         "The student's next_due_date is updated accordingly."
     ),
 )
@@ -153,14 +158,21 @@ async def create_payment(
     description="Retrieve a paginated list of payments with optional filters.",
 )
 async def list_payments(
-    student_id: Optional[int] = Query(None, description="Filter by student ID"),
+    student_id: Optional[int] = Query(
+        None, description="Filter by student ID"
+    ),
     payment_status: Optional[str] = Query(
         None,
         alias="status",
-        description="Filter by status (Paid, Partial, Pending, Failed, Overdue)",
+        description=(
+            "Filter by status (Paid, Partial, Pending, Failed, "
+            "Overdue)"
+        ),
     ),
     skip: int = Query(0, ge=0, description="Pagination offset"),
-    limit: int = Query(100, ge=1, le=500, description="Maximum records to return"),
+    limit: int = Query(
+        100, ge=1, le=500, description="Maximum records to return"
+    ),
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> List[PaymentResponse]:
@@ -262,7 +274,9 @@ async def get_payment(
             status_code=status.HTTP_404_NOT_FOUND, detail=exc.message
         )
     except DatabaseError as exc:
-        Logger.error(f"Database error while fetching payment {payment_id}: {exc}")
+        Logger.error(
+            f"Database error while fetching payment {payment_id}: {exc}"
+        )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="An error occurred while retrieving the payment.",

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -6,8 +6,7 @@ This module aggregates all v1 API endpoints.
 
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import auth, health, dashboard, class_subjects_router
-from app.api.v1.endpoints.payments import router as payments_router
+from app.api.v1.endpoints import auth, health, dashboard, finance, class_subjects_router, payments_router
 
 # Create v1 router
 router = APIRouter(prefix="/v1")
@@ -16,5 +15,6 @@ router = APIRouter(prefix="/v1")
 router.include_router(auth.router)
 router.include_router(health.router)
 router.include_router(dashboard.router)
+router.include_router(finance.router)
 router.include_router(class_subjects_router)
 router.include_router(payments_router)

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -6,7 +6,14 @@ This module aggregates all v1 API endpoints.
 
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import auth, health, dashboard, finance, class_subjects_router, payments_router
+from app.api.v1.endpoints import (
+    auth,
+    health,
+    dashboard,
+    finance,
+    class_subjects_router,
+    payments_router,
+)
 
 # Create v1 router
 router = APIRouter(prefix="/v1")

--- a/backend/app/domain/entities/__init__.py
+++ b/backend/app/domain/entities/__init__.py
@@ -1,7 +1,12 @@
 """Domain entities."""
 
 from app.domain.entities.user import User, Role, UserRole
-from app.domain.entities.payment import Payment, Student, FeeStructure, PaymentSummary
+from app.domain.entities.payment import (
+    Payment,
+    Student,
+    FeeStructure,
+    PaymentSummary,
+)
 
 __all__ = [
     "User",

--- a/backend/app/domain/entities/fee.py
+++ b/backend/app/domain/entities/fee.py
@@ -1,0 +1,106 @@
+"""
+Domain entities for Fee & Finance management.
+
+Entities represent core business objects with no dependencies
+on external frameworks.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal
+
+
+@dataclass
+class FeeStructure:
+    """
+    FeeStructure entity representing fee configuration.
+
+    Attributes:
+        id: Unique identifier for the fee structure
+        student_id: Student associated with this fee structure
+        fee_head: Name of the fee component (e.g., "Tuition Fee", "Transport Fee")
+        total_amount: Total amount for this fee
+        is_mandatory: Whether this fee is mandatory or optional
+        academic_year: Academic year for this fee
+    """
+
+    id: str
+    student_id: str
+    fee_head: str
+    total_amount: float
+    is_mandatory: bool
+    academic_year: str
+
+
+@dataclass
+class Installment:
+    """
+    Installment entity representing a payment installment.
+
+    Attributes:
+        id: Unique identifier for the installment
+        fee_structure_id: Reference to the fee structure
+        student_id: Student associated with this installment
+        due_date: Due date for the installment
+        amount: Amount due for this installment
+        status: Payment status (Pending, Paid, Overdue)
+        paid_date: Date when the installment was paid (None if not paid)
+    """
+
+    id: str
+    fee_structure_id: str
+    student_id: str
+    due_date: datetime
+    amount: float
+    status: Literal["Pending", "Paid", "Overdue"]
+    paid_date: datetime | None = None
+
+
+@dataclass
+class Transaction:
+    """
+    Transaction entity representing a payment transaction.
+
+    Attributes:
+        id: Unique identifier for the transaction
+        student_id: Student who made the payment
+        installment_id: Reference to the installment (if applicable)
+        amount: Amount paid
+        payment_mode: Mode of payment (UPI, Card, Cash, etc.)
+        transaction_ref: External transaction reference ID
+        receipt_number: Unique receipt number
+        created_at: When the transaction was created
+        description: Optional description of transaction
+    """
+
+    id: str
+    student_id: str
+    installment_id: str | None
+    amount: float
+    payment_mode: Literal["UPI", "Card", "Cash", "Check", "Online"]
+    transaction_ref: str
+    receipt_number: str
+    created_at: datetime
+    description: str | None = None
+
+
+@dataclass
+class FeeSummary:
+    """
+    FeeSummary entity representing aggregated fee information.
+
+    Attributes:
+        student_id: Student ID
+        total_fee: Total fees charged
+        paid_amount: Total amount paid so far
+        balance_due: Remaining balance
+        next_due_date: Date of next due installment
+        status_percentage: Percentage of fees paid (0-100)
+    """
+
+    student_id: str
+    total_fee: float
+    paid_amount: float
+    balance_due: float
+    next_due_date: datetime | None = None
+    status_percentage: float = 0.0

--- a/backend/app/domain/entities/fee.py
+++ b/backend/app/domain/entities/fee.py
@@ -18,7 +18,8 @@ class FeeStructure:
     Attributes:
         id: Unique identifier for the fee structure
         student_id: Student associated with this fee structure
-        fee_head: Name of the fee component (e.g., "Tuition Fee", "Transport Fee")
+        fee_head: Name of the fee component (e.g., "Tuition Fee",
+              "Transport Fee")
         total_amount: Total amount for this fee
         is_mandatory: Whether this fee is mandatory or optional
         academic_year: Academic year for this fee

--- a/backend/app/domain/entities/payment.py
+++ b/backend/app/domain/entities/payment.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Literal, Optional
 
-
 # Supported payment modes
 PaymentMode = Literal["Cash", "UPI", "Card"]
 

--- a/backend/app/domain/entities/user.py
+++ b/backend/app/domain/entities/user.py
@@ -8,7 +8,6 @@ on external frameworks.
 from dataclasses import dataclass
 from typing import Literal
 
-
 # Type alias for user roles
 UserRole = Literal[
     "admin", "teacher", "student", "parent", "transport", "driver"

--- a/backend/app/domain/repositories/fee_repository.py
+++ b/backend/app/domain/repositories/fee_repository.py
@@ -1,0 +1,143 @@
+"""
+Repository interface for Fee-related data access.
+
+This defines the contract for fee data operations.
+"""
+
+from abc import ABC, abstractmethod
+from datetime import datetime
+from app.domain.entities.fee import (
+    FeeStructure,
+    Installment,
+    Transaction,
+    FeeSummary,
+)
+
+
+class FeeRepository(ABC):
+    """Abstract repository for fee operations."""
+
+    @abstractmethod
+    async def get_fee_structure(self, student_id: str) -> list[FeeStructure]:
+        """
+        Retrieve fee structure for a student.
+
+        Args:
+            student_id: The student's unique identifier
+
+        Returns:
+            List of FeeStructure objects
+        """
+        pass
+
+    @abstractmethod
+    async def get_fee_summary(self, student_id: str) -> FeeSummary:
+        """
+        Retrieve aggregated fee summary for a student.
+
+        Args:
+            student_id: The student's unique identifier
+
+        Returns:
+            FeeSummary object with total, paid, and balance information
+        """
+        pass
+
+    @abstractmethod
+    async def get_installments(
+        self, student_id: str, fee_structure_id: str | None = None
+    ) -> list[Installment]:
+        """
+        Retrieve installments for a student.
+
+        Args:
+            student_id: The student's unique identifier
+            fee_structure_id: Optional fee structure filter
+
+        Returns:
+            List of Installment objects
+        """
+        pass
+
+    @abstractmethod
+    async def get_transactions(
+        self,
+        student_id: str,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list[Transaction]:
+        """
+        Retrieve transaction history for a student.
+
+        Args:
+            student_id: The student's unique identifier
+            limit: Maximum number of transactions to return
+            offset: Number of transactions to skip
+
+        Returns:
+            List of Transaction objects
+        """
+        pass
+
+    @abstractmethod
+    async def get_transaction_by_receipt(
+        self, receipt_number: str
+    ) -> Transaction | None:
+        """
+        Retrieve a transaction by receipt number.
+
+        Args:
+            receipt_number: The receipt number to search for
+
+        Returns:
+            Transaction object or None if not found
+        """
+        pass
+
+    @abstractmethod
+    async def create_transaction(
+        self,
+        student_id: str,
+        installment_id: str | None,
+        amount: float,
+        payment_mode: str,
+        transaction_ref: str,
+        receipt_number: str,
+        description: str | None = None,
+    ) -> Transaction:
+        """
+        Create a new transaction record.
+
+        Args:
+            student_id: Student making the payment
+            installment_id: Installment being paid (optional)
+            amount: Amount being paid
+            payment_mode: Mode of payment
+            transaction_ref: External transaction reference
+            receipt_number: Unique receipt number
+            description: Optional description
+
+        Returns:
+            Created Transaction object
+        """
+        pass
+
+    @abstractmethod
+    async def update_installment_status(
+        self,
+        installment_id: str,
+        status: str,
+        paid_date: datetime | None = None,
+    ) -> Installment:
+        """
+        Update installment payment status.
+
+        Args:
+            installment_id: The installment to update
+            status: New status (Pending, Paid, Overdue)
+            paid_date: Date of payment (if applicable)
+
+        Returns:
+            Updated Installment object
+        """
+        pass

--- a/backend/app/domain/usecases/fee_usecases.py
+++ b/backend/app/domain/usecases/fee_usecases.py
@@ -1,0 +1,195 @@
+"""
+Use cases for Fee Management operations.
+
+Business logic for fee-related operations.
+"""
+
+from abc import ABC, abstractmethod
+from datetime import datetime
+from app.domain.entities.fee import (
+    FeeStructure,
+    Installment,
+    Transaction,
+    FeeSummary,
+)
+from app.domain.repositories.fee_repository import FeeRepository
+
+
+class GetFeeStructureUseCase(ABC):
+    """Use case for retrieving fee structure."""
+
+    @abstractmethod
+    async def execute(self, student_id: str) -> list[FeeStructure]:
+        """Get fee structure for a student."""
+        pass
+
+
+class GetFeeSummaryUseCase(ABC):
+    """Use case for retrieving fee summary."""
+
+    @abstractmethod
+    async def execute(self, student_id: str) -> FeeSummary:
+        """Get aggregated fee summary for a student."""
+        pass
+
+
+class GetInstallmentsUseCase(ABC):
+    """Use case for retrieving fee installments."""
+
+    @abstractmethod
+    async def execute(
+        self, student_id: str, fee_structure_id: str | None = None
+    ) -> list[Installment]:
+        """Get installments for a student."""
+        pass
+
+
+class GetTransactionHistoryUseCase(ABC):
+    """Use case for retrieving transaction history."""
+
+    @abstractmethod
+    async def execute(
+        self,
+        student_id: str,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list[Transaction]:
+        """Get transaction history for a student."""
+        pass
+
+
+class GetReceiptDetailsUseCase(ABC):
+    """Use case for retrieving receipt details."""
+
+    @abstractmethod
+    async def execute(self, receipt_number: str) -> Transaction | None:
+        """Get receipt details by receipt number."""
+        pass
+
+
+class ProcessPaymentUseCase(ABC):
+    """Use case for processing payments."""
+
+    @abstractmethod
+    async def execute(
+        self,
+        student_id: str,
+        installment_id: str | None,
+        amount: float,
+        payment_mode: str,
+        transaction_ref: str,
+        description: str | None = None,
+    ) -> Transaction:
+        """
+        Process a payment and create transaction record.
+        Generates receipt number and updates installment status.
+        """
+        pass
+
+
+# Concrete implementations
+
+
+class GetFeeStructureUseCaseImpl(GetFeeStructureUseCase):
+    """Concrete implementation for retrieving fee structure."""
+
+    def __init__(self, repository: FeeRepository):
+        self.repository = repository
+
+    async def execute(self, student_id: str) -> list[FeeStructure]:
+        return await self.repository.get_fee_structure(student_id)
+
+
+class GetFeeSummaryUseCaseImpl(GetFeeSummaryUseCase):
+    """Concrete implementation for retrieving fee summary."""
+
+    def __init__(self, repository: FeeRepository):
+        self.repository = repository
+
+    async def execute(self, student_id: str) -> FeeSummary:
+        return await self.repository.get_fee_summary(student_id)
+
+
+class GetInstallmentsUseCaseImpl(GetInstallmentsUseCase):
+    """Concrete implementation for retrieving installments."""
+
+    def __init__(self, repository: FeeRepository):
+        self.repository = repository
+
+    async def execute(
+        self, student_id: str, fee_structure_id: str | None = None
+    ) -> list[Installment]:
+        return await self.repository.get_installments(
+            student_id, fee_structure_id
+        )
+
+
+class GetTransactionHistoryUseCaseImpl(GetTransactionHistoryUseCase):
+    """Concrete implementation for retrieving transaction history."""
+
+    def __init__(self, repository: FeeRepository):
+        self.repository = repository
+
+    async def execute(
+        self,
+        student_id: str,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list[Transaction]:
+        return await self.repository.get_transactions(
+            student_id, limit, offset
+        )
+
+
+class GetReceiptDetailsUseCaseImpl(GetReceiptDetailsUseCase):
+    """Concrete implementation for retrieving receipt details."""
+
+    def __init__(self, repository: FeeRepository):
+        self.repository = repository
+
+    async def execute(self, receipt_number: str) -> Transaction | None:
+        return await self.repository.get_transaction_by_receipt(receipt_number)
+
+
+class ProcessPaymentUseCaseImpl(ProcessPaymentUseCase):
+    """Concrete implementation for processing payments."""
+
+    def __init__(self, repository: FeeRepository):
+        self.repository = repository
+
+    async def execute(
+        self,
+        student_id: str,
+        installment_id: str | None,
+        amount: float,
+        payment_mode: str,
+        transaction_ref: str,
+        description: str | None = None,
+    ) -> Transaction:
+        """
+        Process payment: create transaction and update installment.
+        """
+        from uuid import uuid4
+
+        receipt_number = f"REC-{uuid4().hex[:8].upper()}"
+
+        # Create transaction
+        transaction = await self.repository.create_transaction(
+            student_id=student_id,
+            installment_id=installment_id,
+            amount=amount,
+            payment_mode=payment_mode,
+            transaction_ref=transaction_ref,
+            receipt_number=receipt_number,
+            description=description,
+        )
+
+        # Update installment status if applicable
+        if installment_id:
+            await self.repository.update_installment_status(
+                installment_id=installment_id,
+                status="Paid",
+                paid_date=datetime.now(),
+            )
+
+        return transaction

--- a/backend/app/domain/usecases/payment_usecases.py
+++ b/backend/app/domain/usecases/payment_usecases.py
@@ -18,10 +18,10 @@ from app.domain.entities.payment import (
 )
 from app.domain.repositories.payment_repository import PaymentRepository
 
-
 # ------------------------------------------------------------------ #
 # Helpers
 # ------------------------------------------------------------------ #
+
 
 def _generate_receipt_number() -> str:
     """
@@ -41,6 +41,7 @@ def _generate_receipt_number() -> str:
 # ------------------------------------------------------------------ #
 # Use cases
 # ------------------------------------------------------------------ #
+
 
 class RecordPaymentUseCase:
     """
@@ -118,7 +119,8 @@ class RecordPaymentUseCase:
             )
         if fee_structure.student_id != student_id:
             raise ValidationError(
-                f"Fee structure {fee_structure_id} does not belong to student {student_id}."
+                f"Fee structure {fee_structure_id} does not belong to "
+                f"student {student_id}."
             )
 
         # 4. Determine payment status based on amount vs. balance

--- a/backend/app/domain/usecases/update_class_subjects.py
+++ b/backend/app/domain/usecases/update_class_subjects.py
@@ -10,7 +10,6 @@ to the database.
 
 
 class UpdateClassSubjectsUseCase:
-
     def __init__(self, class_repo, subject_repo, db):
         self.class_repo = class_repo
         self.subject_repo = subject_repo
@@ -28,7 +27,6 @@ class UpdateClassSubjectsUseCase:
 
         # 2️⃣ Process subjects
         for subject in subjects:
-
             # If ID is provided → existing subject
             if subject.get("id"):
                 subject_obj = await self.subject_repo.get_by_id(subject["id"])
@@ -36,18 +34,18 @@ class UpdateClassSubjectsUseCase:
                 if not subject_obj:
                     raise Exception(
                         f"Subject with id {subject['id']} not found"
-                        )
+                    )
 
             # If name is provided → find or create
             else:
                 subject_obj = await self.subject_repo.get_by_name(
                     subject["name"]
-                    )
+                )
 
                 if not subject_obj:
                     subject_obj = await self.subject_repo.create(
                         subject["name"]
-                        )
+                    )
 
             subject_entities.append(subject_obj)
 

--- a/backend/app/infrastructure/database/database.py
+++ b/backend/app/infrastructure/database/database.py
@@ -22,7 +22,6 @@ from sqlalchemy.ext.asyncio import (
 from app.core.config import settings
 from app.infrastructure.database.models import Base
 
-
 # Create async engine with connection pooling
 engine = create_async_engine(
     settings.database_url,

--- a/backend/app/infrastructure/database/models.py
+++ b/backend/app/infrastructure/database/models.py
@@ -65,17 +65,17 @@ class UserModel(Base):
 
     email: Mapped[str] = mapped_column(
         String(255), unique=True, index=True, nullable=False
-        )
+    )
     password_hash: Mapped[str] = mapped_column(String(255), nullable=False)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
 
     is_active: Mapped[bool] = mapped_column(
         Boolean, default=True, nullable=False
-        )
+    )
 
     created_at: Mapped[datetime] = mapped_column(
         DateTime, default=datetime.utcnow, nullable=False
-        )
+    )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime,
         default=datetime.utcnow,
@@ -93,9 +93,7 @@ class UserModel(Base):
 
     def __repr__(self) -> str:
         return (
-            f"<User(id={self.id}, "
-            f"email='{self.email}', "
-            f"name='{self.name}')>"
+            f"<User(id={self.id}, email='{self.email}', name='{self.name}')>"
         )
 
 
@@ -112,7 +110,7 @@ class RoleModel(Base):
 
     name: Mapped[str] = mapped_column(
         String(50), unique=True, nullable=False, index=True
-        )
+    )
 
     description: Mapped[str | None] = mapped_column(String(255), nullable=True)
 
@@ -216,7 +214,9 @@ class StudentModel(Base):
 
     # Relationships
     fee_structures: Mapped[List["FeeStructureModel"]] = relationship(
-        "FeeStructureModel", back_populates="student", cascade="all, delete-orphan"
+        "FeeStructureModel",
+        back_populates="student",
+        cascade="all, delete-orphan",
     )
     payments: Mapped[List["PaymentModel"]] = relationship(
         "PaymentModel", back_populates="student", cascade="all, delete-orphan"
@@ -245,7 +245,9 @@ class FeeStructureModel(Base):
         Integer, ForeignKey("students.id", ondelete="CASCADE"), nullable=False
     )
     total_fee: Mapped[float] = mapped_column(Float, nullable=False)
-    amount_paid: Mapped[float] = mapped_column(Float, default=0.0, nullable=False)
+    amount_paid: Mapped[float] = mapped_column(
+        Float, default=0.0, nullable=False
+    )
     fee_type: Mapped[str] = mapped_column(
         String(100), nullable=False, default="Tuition"
     )

--- a/backend/app/infrastructure/database/seed.py
+++ b/backend/app/infrastructure/database/seed.py
@@ -20,7 +20,6 @@ from app.core.password import hash_password
 from app.infrastructure.database.database import AsyncSessionLocal, init_db
 from app.infrastructure.database.models import RoleModel, UserModel
 
-
 # Demo users configuration
 DEMO_USERS = [
     {

--- a/backend/app/infrastructure/repositories/database_auth_repository.py
+++ b/backend/app/infrastructure/repositories/database_auth_repository.py
@@ -128,8 +128,6 @@ class DatabaseAuthRepository(AuthRepository):
             return self._to_domain_entity(user_model)
 
         except Exception as e:
-            from app.core.errors import NotFoundError
-
             if isinstance(e, NotFoundError):
                 raise
             Logger.error(f"Database error getting user: {e}", exc_info=True)

--- a/backend/app/infrastructure/repositories/database_payment_repository.py
+++ b/backend/app/infrastructure/repositories/database_payment_repository.py
@@ -62,7 +62,9 @@ class DatabasePaymentRepository(PaymentRepository):
 
     @staticmethod
     def _fee_structure_to_entity(model: FeeStructureModel) -> FeeStructure:
-        """Map a FeeStructureModel ORM object to a FeeStructure domain entity."""
+        """Map a FeeStructureModel ORM object to a FeeStructure
+        domain entity.
+        """
         return FeeStructure(
             id=model.id,
             student_id=model.student_id,
@@ -153,8 +155,14 @@ class DatabasePaymentRepository(PaymentRepository):
                     )
                     .join(
                         latest_date_subq,
-                        (PaymentModel.student_id == latest_date_subq.c.student_id)
-                        & (PaymentModel.payment_date == latest_date_subq.c.max_date),
+                        (
+                            PaymentModel.student_id
+                            == latest_date_subq.c.student_id
+                        )
+                        & (
+                            PaymentModel.payment_date
+                            == latest_date_subq.c.max_date
+                        ),
                     )
                     .subquery()
                 )
@@ -184,9 +192,7 @@ class DatabasePaymentRepository(PaymentRepository):
             Logger.error(f"Error listing students: {exc}")
             raise DatabaseError("Failed to list students.") from exc
 
-    async def _latest_payment_status(
-        self, student_id: int
-    ) -> Optional[str]:
+    async def _latest_payment_status(self, student_id: int) -> Optional[str]:
         """Return the most recent payment status for a student."""
         result = await self.db.execute(
             select(PaymentModel.status)
@@ -391,9 +397,7 @@ class DatabasePaymentRepository(PaymentRepository):
                 query = query.where(PaymentModel.status == status)
             query = query.offset(skip).limit(limit)
             result = await self.db.execute(query)
-            return [
-                self._payment_to_entity(m) for m in result.scalars().all()
-            ]
+            return [self._payment_to_entity(m) for m in result.scalars().all()]
         except Exception as exc:
             Logger.error(f"Error listing payments: {exc}")
             raise DatabaseError("Failed to list payments.") from exc
@@ -421,12 +425,14 @@ class DatabasePaymentRepository(PaymentRepository):
             )
             total_collected: float = total_collected_result.scalar() or 0.0
 
-            # Overdue = outstanding balances for students past their next_due_date
+            # Overdue = outstanding balances for students
+            # past their next_due_date
             overdue_result = await self.db.execute(
                 select(
                     func.coalesce(
                         func.sum(
-                            FeeStructureModel.total_fee - FeeStructureModel.amount_paid
+                            FeeStructureModel.total_fee
+                            - FeeStructureModel.amount_paid
                         ),
                         0,
                     )
@@ -437,7 +443,8 @@ class DatabasePaymentRepository(PaymentRepository):
                 )
                 .where(
                     StudentModel.next_due_date < datetime.utcnow(),
-                    FeeStructureModel.total_fee > FeeStructureModel.amount_paid,
+                    FeeStructureModel.total_fee
+                    > FeeStructureModel.amount_paid,
                 )
             )
             total_overdue: float = overdue_result.scalar() or 0.0
@@ -472,9 +479,5 @@ class DatabasePaymentRepository(PaymentRepository):
             )
             return result.scalar_one_or_none() is not None
         except Exception as exc:
-            Logger.error(
-                f"Error checking receipt number existence: {exc}"
-            )
-            raise DatabaseError(
-                "Failed to check receipt number."
-            ) from exc
+            Logger.error(f"Error checking receipt number existence: {exc}")
+            raise DatabaseError("Failed to check receipt number.") from exc

--- a/backend/app/infrastructure/repositories/subject_repository.py
+++ b/backend/app/infrastructure/repositories/subject_repository.py
@@ -9,7 +9,6 @@ from app.infrastructure.database.models import SubjectModel
 
 
 class SubjectRepository:
-
     def __init__(self, db: AsyncSession):
         self.db = db
 
@@ -18,8 +17,9 @@ class SubjectRepository:
         Fetch subject by ID
         """
 
-        result = await self.db.execute(select(SubjectModel)
-                                       .where(SubjectModel.id == subject_id))
+        result = await self.db.execute(
+            select(SubjectModel).where(SubjectModel.id == subject_id)
+        )
 
         return result.scalar_one_or_none()
 
@@ -28,8 +28,9 @@ class SubjectRepository:
         Fetch subject by name
         """
 
-        result = await self.db.execute(select(SubjectModel)
-                                       .where(SubjectModel.name == name))
+        result = await self.db.execute(
+            select(SubjectModel).where(SubjectModel.name == name)
+        )
 
         return result.scalar_one_or_none()
 

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -14,7 +14,9 @@ from app.main import app
 async def test_health_check():
     """Test that the health check endpoint returns healthy status."""
     transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as client:
+    async with AsyncClient(
+        transport=transport, base_url="http://test"
+    ) as client:
         response = await client.get("/api/v1/health")
 
     assert response.status_code == 200
@@ -27,7 +29,9 @@ async def test_health_check():
 async def test_root_endpoint():
     """Test that the root endpoint returns API information."""
     transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as client:
+    async with AsyncClient(
+        transport=transport, base_url="http://test"
+    ) as client:
         response = await client.get("/")
 
     assert response.status_code == 200

--- a/mobile/src/presentation/hooks/useFeeData.ts
+++ b/mobile/src/presentation/hooks/useFeeData.ts
@@ -1,0 +1,113 @@
+import { useState, useEffect, useCallback } from 'react';
+import { api } from '@/core/api-client';
+import { useAuth } from './useAuth';
+
+export interface FeeSummary {
+  student_id: string;
+  total_fee: number;
+  paid_amount: number;
+  balance_due: number;
+  next_due_date: string | null;
+  status_percentage: number;
+}
+
+export interface Installment {
+  id: string;
+  fee_structure_id: string;
+  student_id: string;
+  due_date: string;
+  amount: number;
+  status: 'Pending' | 'Paid' | 'Overdue';
+  paid_date?: string;
+}
+
+export interface Transaction {
+  id: string;
+  student_id: string;
+  installment_id: string | null;
+  amount: number;
+  payment_mode: 'UPI' | 'Card' | 'Cash' | 'Check' | 'Online';
+  transaction_ref: string;
+  receipt_number: string;
+  created_at: string;
+  description?: string;
+}
+
+interface UseFeeDataResult {
+  feeSummary: FeeSummary | null;
+  installments: Installment[];
+  transactions: Transaction[];
+  loading: boolean;
+  error: string | null;
+  refetch: () => Promise<void>;
+}
+
+/**
+ * Hook to fetch student fee data including summary, installments, and transactions
+ * @param studentId - The student ID to fetch data for
+ * @returns Object containing fee data and loading states
+ */
+export const useFeeData = (studentId: string): UseFeeDataResult => {
+  const { user } = useAuth();
+  const [feeSummary, setFeeSummary] = useState<FeeSummary | null>(null);
+  const [installments, setInstallments] = useState<Installment[]>([]);
+  const [transactions, setTransactions] = useState<Transaction[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchFeeData = useCallback(async () => {
+    if (!studentId) {
+      setError('Student ID is required');
+      setLoading(false);
+      return;
+    }
+
+    try {
+      setLoading(true);
+      setError(null);
+
+      // Fetch fee summary
+      const summaryResponse = await api.get(
+        `/finance/student/${studentId}/fee-summary`
+      );
+      setFeeSummary(summaryResponse.data);
+
+      // Fetch installments
+      const installmentsResponse = await api.get(
+        `/finance/student/${studentId}/installments`
+      );
+      setInstallments(installmentsResponse.data);
+
+      // Fetch transactions/receipts
+      const transactionsResponse = await api.get(
+        `/finance/student/${studentId}/receipts`,
+        { params: { limit: 50, offset: 0 } }
+      );
+      setTransactions(transactionsResponse.data);
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : 'Failed to fetch fee data';
+      setError(errorMessage);
+      console.error('Error fetching fee data:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, [studentId]);
+
+  useEffect(() => {
+    fetchFeeData();
+  }, [fetchFeeData]);
+
+  const refetch = async () => {
+    await fetchFeeData();
+  };
+
+  return {
+    feeSummary,
+    installments,
+    transactions,
+    loading,
+    error,
+    refetch,
+  };
+};

--- a/mobile/src/presentation/screens/FeeLedgerScreen.tsx
+++ b/mobile/src/presentation/screens/FeeLedgerScreen.tsx
@@ -1,0 +1,280 @@
+import React, { useState, useCallback } from 'react';
+import { View, ScrollView, RefreshControl, StyleSheet, StatusBar, SectionList } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useTheme } from '@/core/theme/ThemeContext';
+import { ThemedView } from '@/presentation/components/ThemedView';
+import { ThemedText } from '@/presentation/components/ThemedText';
+import { ThemedCard } from '@/presentation/components/ThemedCard';
+import { Ionicons } from '@expo/vector-icons';
+
+interface Installment {
+  id: string;
+  fee_structure_id: string;
+  student_id: string;
+  due_date: string;
+  amount: number;
+  status: 'Pending' | 'Paid' | 'Overdue';
+  paid_date?: string;
+}
+
+interface GroupedInstallments {
+  title: string;
+  data: Installment[];
+}
+
+export function FeeLedgerScreen() {
+  const { theme } = useTheme();
+  const [refreshing, setRefreshing] = useState(false);
+
+  const mockInstallments: Installment[] = [
+    {
+      id: 'inst-001',
+      fee_structure_id: 'fs-001',
+      student_id: 'std-123',
+      due_date: '2024-04-15',
+      amount: 25000,
+      status: 'Paid',
+      paid_date: '2024-04-10',
+    },
+    {
+      id: 'inst-002',
+      fee_structure_id: 'fs-001',
+      student_id: 'std-123',
+      due_date: '2024-07-15',
+      amount: 25000,
+      status: 'Pending',
+    },
+    {
+      id: 'inst-003',
+      fee_structure_id: 'fs-002',
+      student_id: 'std-123',
+      due_date: '2024-05-01',
+      amount: 15000,
+      status: 'Pending',
+    },
+  ];
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      // TODO: Fetch from API
+      await new Promise(resolve => setTimeout(resolve, 1000));
+    } finally {
+      setRefreshing(false);
+    }
+  }, []);
+
+  const groupedData: GroupedInstallments[] = [
+    {
+      title: 'Tuition Fee',
+      data: mockInstallments.filter(i => i.fee_structure_id === 'fs-001'),
+    },
+    {
+      title: 'Transport Fee',
+      data: mockInstallments.filter(i => i.fee_structure_id === 'fs-002'),
+    },
+  ];
+
+  const formatCurrency = (amount: number) => {
+    return new Intl.NumberFormat('en-IN', {
+      style: 'currency',
+      currency: 'INR',
+    }).format(amount);
+  };
+
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case 'Paid':
+        return '#10b981';
+      case 'Overdue':
+        return '#ef4444';
+      case 'Pending':
+      default:
+        return '#f59e0b';
+    }
+  };
+
+  const getStatusIcon = (status: string) => {
+    switch (status) {
+      case 'Paid':
+        return '✓';
+      case 'Overdue':
+        return '!';
+      case 'Pending':
+      default:
+        return '○';
+    }
+  };
+
+  const renderInstallment = ({ item }: { item: Installment }) => (
+    <ThemedCard style={styles.installmentCard} padding={12}>
+      <View style={styles.installmentContent}>
+        <View style={styles.installmentLeft}>
+          <View
+            style={[
+              styles.statusIcon,
+              { backgroundColor: getStatusColor(item.status) + '20' },
+            ]}
+          >
+            <ThemedText style={{ color: getStatusColor(item.status) }}>
+              {getStatusIcon(item.status)}
+            </ThemedText>
+          </View>
+          <View style={styles.installmentInfo}>
+            <ThemedText type="defaultSemiBold" style={styles.dueDate}>
+              {new Date(item.due_date).toLocaleDateString('en-IN', {
+                month: 'short',
+                day: 'numeric',
+                year: 'numeric',
+              })}
+            </ThemedText>
+            <ThemedText
+              type="default"
+              lightColor="#666"
+              darkColor="#999"
+              style={styles.statusText}
+            >
+              {item.status}
+              {item.paid_date && ` on ${new Date(item.paid_date).toLocaleDateString('en-IN')}`}
+            </ThemedText>
+          </View>
+        </View>
+        <View style={styles.installmentAmount}>
+          <ThemedText type="defaultSemiBold" style={styles.amount}>
+            {formatCurrency(item.amount)}
+          </ThemedText>
+        </View>
+      </View>
+    </ThemedCard>
+  );
+
+  const renderSectionHeader = ({ section: { title } }: { section: GroupedInstallments }) => (
+    <View style={styles.sectionHeader}>
+      <ThemedText type="subtitle" style={styles.sectionTitle}>
+        {title}
+      </ThemedText>
+    </View>
+  );
+
+  const renderSectionFooter = ({ section: { data } }: { section: GroupedInstallments }) => {
+    const total = data.reduce((sum, item) => sum + item.amount, 0);
+    return (
+      <View style={[styles.sectionFooter, { borderTopColor: theme.colors.border }]}>
+        <ThemedText type="default" lightColor="#666" darkColor="#999">
+          Subtotal:
+        </ThemedText>
+        <ThemedText type="defaultSemiBold">{formatCurrency(total)}</ThemedText>
+      </View>
+    );
+  };
+
+  return (
+    <ThemedView style={styles.container}>
+      <StatusBar barStyle="light-content" />
+      <SafeAreaView edges={['top']} style={styles.safeArea}>
+        <View style={[styles.header, { backgroundColor: theme.colors.primary }]}>
+          <ThemedText style={styles.headerTitle} type="title" color="primaryForeground">
+            Fee Ledger & Installments
+          </ThemedText>
+          <ThemedText style={styles.headerSubtitle} color="primaryForeground">
+            Detailed breakdown of all fee installments
+          </ThemedText>
+        </View>
+      </SafeAreaView>
+
+      <SectionList
+        sections={groupedData}
+        keyExtractor={(item, index) => item.id + index}
+        renderItem={renderInstallment}
+        renderSectionHeader={renderSectionHeader}
+        renderSectionFooter={renderSectionFooter}
+        contentContainerStyle={styles.listContent}
+        scrollEnabled={true}
+        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={theme.colors.primary} />}
+      />
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  safeArea: {
+    width: '100%',
+  },
+  header: {
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  headerTitle: {
+    fontSize: 24,
+    fontWeight: 'bold',
+  },
+  headerSubtitle: {
+    fontSize: 12,
+    marginTop: 4,
+    opacity: 0.8,
+  },
+  listContent: {
+    padding: 16,
+    paddingTop: 8,
+  },
+  sectionHeader: {
+    marginTop: 16,
+    marginBottom: 8,
+  },
+  sectionTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  installmentCard: {
+    marginBottom: 8,
+    borderRadius: 8,
+  },
+  installmentContent: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  installmentLeft: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  statusIcon: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    justifyContent: 'center',
+    alignItems: 'center',
+    fontWeight: 'bold',
+    fontSize: 16,
+  },
+  installmentInfo: {
+    flex: 1,
+  },
+  dueDate: {
+    fontSize: 14,
+  },
+  statusText: {
+    fontSize: 12,
+    marginTop: 2,
+  },
+  installmentAmount: {
+    alignItems: 'flex-end',
+  },
+  amount: {
+    fontSize: 14,
+    color: '#1f2937',
+  },
+  sectionFooter: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingHorizontal: 8,
+    paddingVertical: 12,
+    marginBottom: 16,
+    borderTopWidth: 1,
+  },
+});

--- a/mobile/src/presentation/screens/FeeStatusScreen.tsx
+++ b/mobile/src/presentation/screens/FeeStatusScreen.tsx
@@ -1,0 +1,255 @@
+import React, { useState, useCallback } from 'react';
+import { View, ScrollView, RefreshControl, StyleSheet, StatusBar } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useTheme } from '@/core/theme/ThemeContext';
+import { ThemedView } from '@/presentation/components/ThemedView';
+import { ThemedText } from '@/presentation/components/ThemedText';
+import { ThemedCard } from '@/presentation/components/ThemedCard';
+import { Ionicons } from '@expo/vector-icons';
+
+interface FeeSummary {
+  student_id: string;
+  total_fee: number;
+  paid_amount: number;
+  balance_due: number;
+  next_due_date: string | null;
+  status_percentage: number;
+}
+
+export function FeeStatusScreen() {
+  const { theme } = useTheme();
+  const [loading, setLoading] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [feeSummary, setFeeSummary] = useState<FeeSummary>({
+    student_id: 'std-123',
+    total_fee: 70000,
+    paid_amount: 35000,
+    balance_due: 35000,
+    next_due_date: '2024-05-15',
+    status_percentage: 50,
+  });
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      // TODO: Fetch from API
+      await new Promise(resolve => setTimeout(resolve, 1000));
+    } finally {
+      setRefreshing(false);
+    }
+  }, []);
+
+  const formatCurrency = (amount: number) => {
+    return new Intl.NumberFormat('en-IN', {
+      style: 'currency',
+      currency: 'INR',
+    }).format(amount);
+  };
+
+  const ProgressBar = ({ percentage }: { percentage: number }) => (
+    <View style={[styles.progressBarContainer, { backgroundColor: theme.colors.border }]}>
+      <View
+        style={[
+          styles.progressBar,
+          {
+            backgroundColor: percentage > 75 ? '#10b981' : percentage > 50 ? '#f59e0b' : '#ef4444',
+            width: `${percentage}%`,
+          },
+        ]}
+      />
+    </View>
+  );
+
+  return (
+    <ThemedView style={styles.container}>
+      <StatusBar barStyle="light-content" />
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={styles.scrollContent}
+        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={theme.colors.primary} />}
+      >
+        {/* Header */}
+        <SafeAreaView edges={['top']}>
+          <View style={[styles.header, { backgroundColor: theme.colors.primary }]}>
+            <ThemedText style={styles.headerTitle} type="title" color="primaryForeground">
+              Fee Status & Ledger
+            </ThemedText>
+          </View>
+        </SafeAreaView>
+
+        {/* Fee Summary Cards */}
+        <View style={styles.cardsContainer}>
+          {/* Total Fee Card */}
+          <ThemedCard style={[styles.summaryCard, { backgroundColor: theme.colors.primary + '10' }]} padding={16}>
+            <View style={styles.cardHeader}>
+              <View style={[styles.cardIcon, { backgroundColor: theme.colors.primary + '20' }]}>
+                <Ionicons name="calculator" size={24} color={theme.colors.primary} />
+              </View>
+              <ThemedText style={styles.cardLabel} lightColor="#666" darkColor="#999">
+                Total Fee
+              </ThemedText>
+            </View>
+            <ThemedText style={styles.cardValue} type="defaultSemiBold">
+              {formatCurrency(feeSummary.total_fee)}
+            </ThemedText>
+          </ThemedCard>
+
+          {/* Paid Amount Card */}
+          <ThemedCard style={[styles.summaryCard, { backgroundColor: '#10b98110' }]} padding={16}>
+            <View style={styles.cardHeader}>
+              <View style={[styles.cardIcon, { backgroundColor: '#10b98120' }]}>
+                <Ionicons name="checkmark-circle" size={24} color="#10b981" />
+              </View>
+              <ThemedText style={styles.cardLabel} lightColor="#666" darkColor="#999">
+                Paid Amount
+              </ThemedText>
+            </View>
+            <ThemedText style={styles.cardValue} type="defaultSemiBold" lightColor="#10b981" darkColor="#10b981">
+              {formatCurrency(feeSummary.paid_amount)}
+            </ThemedText>
+          </ThemedCard>
+
+          {/* Balance Due Card */}
+          <ThemedCard style={[styles.summaryCard, { backgroundColor: '#ef444410' }]} padding={16}>
+            <View style={styles.cardHeader}>
+              <View style={[styles.cardIcon, { backgroundColor: '#ef444420' }]}>
+                <Ionicons name="alert-circle" size={24} color="#ef4444" />
+              </View>
+              <ThemedText style={styles.cardLabel} lightColor="#666" darkColor="#999">
+                Balance Due
+              </ThemedText>
+            </View>
+            <ThemedText style={styles.cardValue} type="defaultSemiBold" lightColor="#ef4444" darkColor="#ef4444">
+              {formatCurrency(feeSummary.balance_due)}
+            </ThemedText>
+          </ThemedCard>
+        </View>
+
+        {/* Payment Progress */}
+        <View style={styles.section}>
+          <ThemedText style={styles.sectionTitle} type="subtitle">
+            Payment Progress
+          </ThemedText>
+          <ThemedCard padding={16}>
+            <View style={styles.progressInfo}>
+              <ThemedText type="default" lightColor="#666" darkColor="#999">
+                {feeSummary.status_percentage.toFixed(1)}% Paid
+              </ThemedText>
+              <ThemedText type="default" lightColor="#666" darkColor="#999">
+                {formatCurrency(feeSummary.balance_due)} Remaining
+              </ThemedText>
+            </View>
+            <ProgressBar percentage={feeSummary.status_percentage} />
+          </ThemedCard>
+        </View>
+
+        {/* Next Due Date */}
+        {feeSummary.next_due_date && (
+          <View style={styles.section}>
+            <ThemedCard style={[styles.nextDueCard, { backgroundColor: theme.colors.primary + '10' }]} padding={16}>
+              <View style={styles.nextDueContent}>
+                <Ionicons name="calendar" size={24} color={theme.colors.primary} />
+                <View style={styles.nextDueText}>
+                  <ThemedText type="default" lightColor="#666" darkColor="#999">
+                    Next Due Date
+                  </ThemedText>
+                  <ThemedText type="defaultSemiBold" style={{ marginTop: 4 }}>
+                    {new Date(feeSummary.next_due_date).toLocaleDateString('en-IN', {
+                      year: 'numeric',
+                      month: 'long',
+                      day: 'numeric',
+                    })}
+                  </ThemedText>
+                </View>
+              </View>
+            </ThemedCard>
+          </View>
+        )}
+      </ScrollView>
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  scrollView: {
+    flex: 1,
+  },
+  scrollContent: {
+    paddingBottom: 20,
+  },
+  header: {
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  headerTitle: {
+    fontSize: 24,
+    fontWeight: 'bold',
+  },
+  cardsContainer: {
+    padding: 16,
+    gap: 12,
+  },
+  summaryCard: {
+    borderRadius: 12,
+    elevation: 2,
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 12,
+    gap: 8,
+  },
+  cardIcon: {
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  cardLabel: {
+    fontSize: 12,
+    fontWeight: '500',
+  },
+  cardValue: {
+    fontSize: 20,
+    fontWeight: '600',
+  },
+  section: {
+    paddingHorizontal: 16,
+    marginBottom: 16,
+  },
+  sectionTitle: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    marginBottom: 12,
+  },
+  progressInfo: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 12,
+  },
+  progressBarContainer: {
+    height: 8,
+    borderRadius: 4,
+    overflow: 'hidden',
+  },
+  progressBar: {
+    height: '100%',
+    borderRadius: 4,
+  },
+  nextDueCard: {
+    borderRadius: 12,
+    elevation: 2,
+  },
+  nextDueContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  nextDueText: {
+    flex: 1,
+  },
+});

--- a/mobile/src/presentation/screens/ReceiptsScreen.tsx
+++ b/mobile/src/presentation/screens/ReceiptsScreen.tsx
@@ -122,16 +122,16 @@ export function ReceiptsScreen() {
             style={[
               styles.searchBox,
               {
-                backgroundColor: theme.colors.cardBackground,
+                backgroundColor: theme.colors.card,
                 borderColor: theme.colors.border,
               },
             ]}
           >
-            <Ionicons name="search" size={20} color={theme.colors.text + '80'} />
+            <Ionicons name="search" size={20} color={theme.colors.foreground + '80'} />
             <TextInput
-              style={[styles.searchInput, { color: theme.colors.text }]}
+              style={[styles.searchInput, { color: theme.colors.foreground }]}
               placeholder="Search by receipt or description..."
-              placeholderTextColor={theme.colors.text + '80'}
+              placeholderTextColor={theme.colors.foreground + '80'}
               value={searchQuery}
               onChangeText={setSearchQuery}
             />
@@ -141,7 +141,7 @@ export function ReceiptsScreen() {
         {/* Transactions List */}
         {filteredTransactions.length === 0 ? (
           <View style={styles.emptyContainer}>
-            <Ionicons name="document-outline" size={48} color={theme.colors.text + '40'} />
+            <Ionicons name="document-outline" size={48} color={theme.colors.foreground + '40'} />
             <ThemedText type="default" style={styles.emptyText} lightColor="#999" darkColor="#666">
               {searchQuery ? 'No receipts found' : 'No payment receipts yet'}
             </ThemedText>

--- a/mobile/src/presentation/screens/ReceiptsScreen.tsx
+++ b/mobile/src/presentation/screens/ReceiptsScreen.tsx
@@ -1,0 +1,336 @@
+import React, { useState, useCallback } from 'react';
+import {
+  View,
+  TextInput,
+  ScrollView,
+  RefreshControl,
+  StyleSheet,
+  StatusBar,
+  TouchableOpacity,
+  Alert,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useTheme } from '@/core/theme/ThemeContext';
+import { ThemedView } from '@/presentation/components/ThemedView';
+import { ThemedText } from '@/presentation/components/ThemedText';
+import { ThemedCard } from '@/presentation/components/ThemedCard';
+import { Ionicons } from '@expo/vector-icons';
+
+interface Transaction {
+  id: string;
+  student_id: string;
+  installment_id: string | null;
+  amount: number;
+  payment_mode: 'UPI' | 'Card' | 'Cash' | 'Check' | 'Online';
+  transaction_ref: string;
+  receipt_number: string;
+  created_at: string;
+  description?: string;
+}
+
+export function ReceiptsScreen() {
+  const { theme } = useTheme();
+  const [refreshing, setRefreshing] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const mockTransactions: Transaction[] = [
+    {
+      id: 'txn-001',
+      student_id: 'std-123',
+      installment_id: 'inst-001',
+      amount: 25000,
+      payment_mode: 'Online',
+      transaction_ref: 'TXN20240410001',
+      receipt_number: 'REC-A1B2C3D4',
+      created_at: '2024-04-10T10:30:00',
+      description: 'Tuition fee installment 1',
+    },
+  ];
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      // TODO: Fetch from API
+      await new Promise(resolve => setTimeout(resolve, 1000));
+    } finally {
+      setRefreshing(false);
+    }
+  }, []);
+
+  const filteredTransactions = mockTransactions.filter(
+    t =>
+      t.receipt_number.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      t.description?.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
+  const formatCurrency = (amount: number) => {
+    return new Intl.NumberFormat('en-IN', {
+      style: 'currency',
+      currency: 'INR',
+    }).format(amount);
+  };
+
+  const getPaymentModeIcon = (mode: string) => {
+    switch (mode) {
+      case 'UPI':
+        return 'phone-portrait';
+      case 'Card':
+        return 'card';
+      case 'Cash':
+        return 'cash';
+      case 'Check':
+        return 'document';
+      case 'Online':
+      default:
+        return 'globe';
+    }
+  };
+
+  const handleViewReceipt = (transaction: Transaction) => {
+    Alert.alert(
+      'Receipt Details',
+      `Receipt Number: ${transaction.receipt_number}\nAmount: ${formatCurrency(transaction.amount)}\nMode: ${transaction.payment_mode}\nRef: ${transaction.transaction_ref}`,
+      [
+        { text: 'Download', onPress: () => Alert.alert('PDF download would be initiated') },
+        { text: 'Close', onPress: () => {} },
+      ]
+    );
+  };
+
+  return (
+    <ThemedView style={styles.container}>
+      <StatusBar barStyle="light-content" />
+      <SafeAreaView edges={['top']} style={styles.safeArea}>
+        <View style={[styles.header, { backgroundColor: theme.colors.primary }]}>
+          <ThemedText style={styles.headerTitle} type="title" color="primaryForeground">
+            Payment Receipts
+          </ThemedText>
+          <ThemedText style={styles.headerSubtitle} color="primaryForeground">
+            View and download transaction receipts
+          </ThemedText>
+        </View>
+      </SafeAreaView>
+
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={styles.scrollContent}
+        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={theme.colors.primary} />}
+      >
+        {/* Search Bar */}
+        <View style={styles.searchContainer}>
+          <View
+            style={[
+              styles.searchBox,
+              {
+                backgroundColor: theme.colors.cardBackground,
+                borderColor: theme.colors.border,
+              },
+            ]}
+          >
+            <Ionicons name="search" size={20} color={theme.colors.text + '80'} />
+            <TextInput
+              style={[styles.searchInput, { color: theme.colors.text }]}
+              placeholder="Search by receipt or description..."
+              placeholderTextColor={theme.colors.text + '80'}
+              value={searchQuery}
+              onChangeText={setSearchQuery}
+            />
+          </View>
+        </View>
+
+        {/* Transactions List */}
+        {filteredTransactions.length === 0 ? (
+          <View style={styles.emptyContainer}>
+            <Ionicons name="document-outline" size={48} color={theme.colors.text + '40'} />
+            <ThemedText type="default" style={styles.emptyText} lightColor="#999" darkColor="#666">
+              {searchQuery ? 'No receipts found' : 'No payment receipts yet'}
+            </ThemedText>
+          </View>
+        ) : (
+          <View style={styles.transactionsList}>
+            {filteredTransactions.map((transaction, index) => (
+              <ThemedCard
+                key={index}
+                style={styles.transactionCard}
+                padding={12}
+              >
+                <View style={styles.transactionHeader}>
+                  <View style={styles.transactionLeft}>
+                    <View
+                      style={[
+                        styles.paymentIcon,
+                        { backgroundColor: theme.colors.primary + '20' },
+                      ]}
+                    >
+                      <Ionicons
+                        name={getPaymentModeIcon(transaction.payment_mode)}
+                        size={20}
+                        color={theme.colors.primary}
+                      />
+                    </View>
+                    <View style={styles.transactionInfo}>
+                      <ThemedText type="defaultSemiBold" style={styles.receiptNumber}>
+                        {transaction.receipt_number}
+                      </ThemedText>
+                      <ThemedText type="default" lightColor="#666" darkColor="#999" style={styles.transactionMode}>
+                        {transaction.payment_mode}
+                      </ThemedText>
+                    </View>
+                  </View>
+                  <View style={styles.transactionRight}>
+                    <ThemedText type="defaultSemiBold" style={styles.transactionAmount}>
+                      {formatCurrency(transaction.amount)}
+                    </ThemedText>
+                    <ThemedText type="default" lightColor="#666" darkColor="#999" style={styles.transactionDate}>
+                      {new Date(transaction.created_at).toLocaleDateString('en-IN')}
+                    </ThemedText>
+                  </View>
+                </View>
+
+                {transaction.description && (
+                  <View style={styles.descriptionContainer}>
+                    <ThemedText type="default" lightColor="#666" darkColor="#999" style={styles.description}>
+                      {transaction.description}
+                    </ThemedText>
+                  </View>
+                )}
+
+                {/* Action Button */}
+                <TouchableOpacity
+                  style={[styles.downloadButton, { backgroundColor: theme.colors.primary }]}
+                  onPress={() => handleViewReceipt(transaction)}
+                >
+                  <Ionicons name="download" size={16} color="#fff" />
+                  <ThemedText style={styles.downloadButtonText} color="primaryForeground">
+                    View & Download
+                  </ThemedText>
+                </TouchableOpacity>
+              </ThemedCard>
+            ))}
+          </View>
+        )}
+      </ScrollView>
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  safeArea: {
+    width: '100%',
+  },
+  header: {
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  headerTitle: {
+    fontSize: 24,
+    fontWeight: 'bold',
+  },
+  headerSubtitle: {
+    fontSize: 12,
+    marginTop: 4,
+    opacity: 0.8,
+  },
+  scrollView: {
+    flex: 1,
+  },
+  scrollContent: {
+    paddingBottom: 20,
+  },
+  searchContainer: {
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  searchBox: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    gap: 8,
+  },
+  searchInput: {
+    flex: 1,
+    fontSize: 14,
+    paddingVertical: 6,
+  },
+  emptyContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingVertical: 60,
+  },
+  emptyText: {
+    marginTop: 12,
+    fontSize: 14,
+  },
+  transactionsList: {
+    paddingHorizontal: 16,
+    gap: 12,
+  },
+  transactionCard: {
+    borderRadius: 12,
+    elevation: 2,
+  },
+  transactionHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  transactionLeft: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  paymentIcon: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  transactionInfo: {
+    flex: 1,
+  },
+  receiptNumber: {
+    fontSize: 14,
+  },
+  transactionMode: {
+    fontSize: 12,
+    marginTop: 2,
+  },
+  transactionRight: {
+    alignItems: 'flex-end',
+  },
+  transactionAmount: {
+    fontSize: 14,
+  },
+  transactionDate: {
+    fontSize: 12,
+    marginTop: 2,
+  },
+  descriptionContainer: {
+    marginBottom: 12,
+  },
+  description: {
+    fontSize: 12,
+  },
+  downloadButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 8,
+    borderRadius: 6,
+    gap: 6,
+  },
+  downloadButtonText: {
+    fontSize: 12,
+    fontWeight: '600',
+  },
+});


### PR DESCRIPTION
- Add domain entities: FeeStructure, Installment, Transaction, FeeSummary
- Create repository interface for fee operations (7 methods)
- Implement use cases for fee management
- Add 5 REST API endpoints for fee operations
- Create 3 frontend screens: FeeStatus, FeeLedger, Receipts
- Add useFeeData hook for centralized data fetching
- Comprehensive documentation and integration guides